### PR TITLE
Updated code for node v4 compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "glpk"
     ],
   "dependencies": {
-    "nan": "^1.8.4",
+    "nan": "^2.1.0",
     "bindings": "^1.2.1"
   },
   "scripts": {

--- a/src/common.h
+++ b/src/common.h
@@ -14,20 +14,20 @@
 #define V8TOCSTRING(S) (*String::Utf8Value(S->ToString()))
 
 #define V8CHECK(T, E) if (T) { \
-    NanThrowTypeError(E);\
+    Nan::ThrowTypeError(E);\
     return; \
  }
 
 #define V8CHECKBOOL(T, E) if (T) { \
-    NanThrowTypeError(E);\
+    Nan::ThrowTypeError(E);\
     return false; \
 }
 
-//catch (std::string s){NanThrowError(s.c_str());return;}
+//catch (std::string s){Nan::ThrowError(s.c_str());return;}
 
-#define GLP_CATCH_RET(X) try{X}catch (std::string s) {NanThrowError(s.c_str());return;}
+#define GLP_CATCH_RET(X) try{X}catch (std::string s) {Nan::ThrowError(s.c_str());return;}
 
-#define GLP_CATCH(X) try{X}catch (std::string s) {NanThrowError(s.c_str());}
+#define GLP_CATCH(X) try{X}catch (std::string s) {Nan::ThrowError(s.c_str());}
 
 #define GLP_DEFINE_CONSTANT(target, constant, name)\
 do {\
@@ -44,149 +44,151 @@ while (0)
 
 #define GLP_BIND_VOID_STR(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 1, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsString(), "Wrong arguments");\
+    V8CHECK(info.Length() != 1, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsString(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, V8TOCSTRING(args[0]));)\
+    GLP_CATCH_RET(API(host->handle, V8TOCSTRING(info[0]));)\
 }
 
 #define GLP_BIND_STR(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(const char* name = API(host->handle);\
-    if (name)\
-        NanReturnValue(name);\
-    else\
-        NanReturnValue("");)\
+    GLP_CATCH_RET(\
+        const char* name = API(host->handle);\
+        if (name)\
+            info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
+        else\
+            info.GetReturnValue().Set(Nan::EmptyString());\
+    )\
 }
 
 #define GLP_BIND_VOID_INT32(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 1, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32(), "Wrong arguments");\
+    V8CHECK(info.Length() != 1, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, args[0]->Int32Value());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value());)\
 }
 
 #define GLP_BIND_VALUE(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(NanReturnValue(API(host->handle));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle));)\
 }
 
 #define GLP_BIND_VOID_INT32_STR(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 2, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32() || !args[1]->IsString(), "Wrong arguments");\
+    V8CHECK(info.Length() != 2, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32() || !info[1]->IsString(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, args[0]->Int32Value(), V8TOCSTRING(args[1]));)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1]));)\
 }
 
 #define GLP_BIND_STR_INT32(CLASS, NAME, API);\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 1, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32(), "Wrong arguments");\
+    V8CHECK(info.Length() != 1, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(const char* name = API(host->handle, args[0]->Int32Value());\
+    GLP_CATCH_RET(const char* name = API(host->handle, info[0]->Int32Value());\
     if (name)\
-        NanReturnValue(name);\
+        info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
     else\
-        NanReturnValue("");)\
+        info.GetReturnValue().Set(Nan::EmptyString());)\
 }
 
 #define GLP_BIND_VOID_INT32_INT32_DOUBLE_DOUBLE(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 4, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32() || !args[1]->IsInt32()\
-            || !args[2]->IsNumber() || !args[3]->IsNumber(), "Wrong arguments");\
+    V8CHECK(info.Length() != 4, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32() || !info[1]->IsInt32()\
+            || !info[2]->IsNumber() || !info[3]->IsNumber(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, args[0]->Int32Value(), args[1]->Int32Value(),\
-                     args[2]->NumberValue(), args[3]->NumberValue());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value(),\
+                     info[2]->NumberValue(), info[3]->NumberValue());)\
 }
 
 #define GLP_BIND_VOID_INT32_DOUBLE(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 2, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32() || !args[1]->IsNumber(), "Wrong arguments");\
+    V8CHECK(info.Length() != 2, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32() || !info[1]->IsNumber(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, args[0]->Int32Value(), args[1]->NumberValue());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->NumberValue());)\
 }
 
 #define GLP_BIND_VALUE_INT32(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 1, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32(), "Wrong arguments");\
+    V8CHECK(info.Length() != 1, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(NanReturnValue(API(host->handle, args[0]->Int32Value()));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value()));)\
 }
 
 #define GLP_BIND_VOID_INT32_INT32ARRAY_FLOAT64ARRAY(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 3, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsUint32() || !args[1]->IsInt32Array() || !args[2]->IsFloat64Array(), "Wrong arguments");\
+    V8CHECK(info.Length() != 3, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsUint32() || !info[1]->IsInt32Array() || !info[2]->IsFloat64Array(), "Wrong arguments");\
     \
-    Local<Int32Array> ja = Local<Int32Array>::Cast(args[1]);\
-    Local<Float64Array> ar = Local<Float64Array>::Cast(args[2]);\
+    Local<Int32Array> ja = Local<Int32Array>::Cast(info[1]);\
+    Local<Float64Array> ar = Local<Float64Array>::Cast(info[2]);\
     \
     uint32_t count = ja->Length();\
     V8CHECK(ar->Length() != count, "the tow arrays must have the same length");\
     count--;\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
@@ -196,7 +198,7 @@ static NAN_METHOD(NAME) {\
     for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();\
     for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();\
     \
-    GLP_CATCH_RET(API(host->handle, args[0]->Int32Value(), count, pja, par);)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), count, pja, par);)\
     \
     free(pja);\
     free(par);\
@@ -204,20 +206,20 @@ static NAN_METHOD(NAME) {\
 
 #define GLP_BIND_VALUE_INT32_CALLBACK(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK((args.Length() < 1) || (args.Length() > 2), "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32(), "Wrong arguments");\
+    V8CHECK((info.Length() < 1) || (info.Length() > 2), "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
     try{\
-        int row = args[0]->Int32Value();\
+        int row = info[0]->Int32Value();\
         int count = API(host->handle, row, NULL, NULL);\
         \
-        if ((args.Length() == 2) && (args[1]->IsFunction())) {\
+        if ((info.Length() == 2) && (info[1]->IsFunction())) {\
             int* idx = (int*)malloc((count + 1) * sizeof(int));\
             double* val = (double*)malloc((count + 1) * sizeof(double));\
             API(host->handle, row, idx, val);\
@@ -228,24 +230,24 @@ static NAN_METHOD(NAME) {\
         	free(idx);\
         	free(val);\
             \
-            Local<Function> cb = Local<Function>::Cast(args[1]);\
+            Local<Function> cb = Local<Function>::Cast(info[1]);\
             const unsigned argc = 2;\
             Local<Value> argv[argc] = {ja, ar};\
             cb->Call(Isolate::GetCurrent()->GetCurrentContext()->Global(), argc, argv);\
-            NanReturnValue(count);\
+            info.GetReturnValue().Set(count);\
         }\
     } catch (std::string s) {\
-        NanThrowError(s.c_str());\
+        Nan::ThrowError(s.c_str());\
     }\
 }
 
 #define GLP_BIND_VOID(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 0, "Wrong number of arguments");\
+    V8CHECK(info.Length() != 0, "Wrong number of arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
@@ -254,18 +256,18 @@ static NAN_METHOD(NAME) {\
 
 #define GLP_BIND_VOID_INT32ARRAY(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 1, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32Array(), "Wrong arguments");\
-    Local<Int32Array> num = Local<Int32Array>::Cast(args[0]);\
+    V8CHECK(info.Length() != 1, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32Array(), "Wrong arguments");\
+    Local<Int32Array> num = Local<Int32Array>::Cast(info[0]);\
     \
     int count = num->Length();\
     V8CHECK(count <= 1, "Invalid Array size");\
     \
     int* idx = (int*)malloc(count * sizeof(int));\
     for (int i = 0; i < count; i++) idx[i] = num->Get(i)->Int32Value();\
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
@@ -276,65 +278,65 @@ static NAN_METHOD(NAME) {\
 
 #define GLP_BIND_VALUE_STR(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 1, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsString(), "Wrong arguments");\
+    V8CHECK(info.Length() != 1, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsString(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(NanReturnValue(API(host->handle, V8TOCSTRING(args[0])));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0])));)\
 }
 
 #define GLP_BIND_VOID_INT32_INT32(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 2, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32() || !args[1]->IsInt32(), "Wrong arguments");\
+    V8CHECK(info.Length() != 2, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32() || !info[1]->IsInt32(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(API(host->handle, args[0]->Int32Value(), args[1]->Int32Value());)\
+    GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value());)\
 }
 
 #define GLP_BIND_VALUE_INT32_STR(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 2, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32() || !args[1]->IsString(), "Wrong arguments");\
+    V8CHECK(info.Length() != 2, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32() || !info[1]->IsString(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(NanReturnValue(API(host->handle, args[0]->Int32Value(), V8TOCSTRING(args[1])));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1])));)\
 }
 
 #define GLP_BIND_VALUE_STR_INT32(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 2, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsString() || !args[1]->IsInt32(), "Wrong arguments");\
+    V8CHECK(info.Length() != 2, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsString() || !info[1]->IsInt32(), "Wrong arguments");\
     \
-    CLASS* host = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* host = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread, "an async operation is inprogress")\
     \
-    GLP_CATCH_RET(args.GetReturnValue().Set(API(host->handle, V8TOCSTRING(args[0]), args[1]->Int32Value()));)\
+    GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0]), info[1]->Int32Value()));)\
 }
 
 #define GLP_BIND_DELETE(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    CLASS* obj = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* obj = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!obj->handle, "object already deleted");\
     V8CHECK(obj->thread, "an async operation is inprogress")\
     \
@@ -343,17 +345,17 @@ static NAN_METHOD(NAME) {\
 }
 
 #define GLP_SET_FIELD_INT32(OBJ, KEY, VALUE)\
-OBJ->Set(NanNew<String>(KEY), NanNew<Int32>(VALUE));
+OBJ->Set(Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Int32>(VALUE));
 
 #define GLP_SET_FIELD_DOUBLE(OBJ, KEY, VALUE)\
-OBJ->Set(NanNew<String>(KEY), NanNew<Number>(VALUE));
+OBJ->Set(Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Number>(VALUE));
 
 
 #define GLP_ASYNC_INT32_STR(CLASS, NAME, API)\
-class NAME##Worker : public NanAsyncWorker {\
+class NAME##Worker : public Nan::AsyncWorker {\
 public:\
-NAME##Worker(NanCallback *callback, CLASS *lp, std::string file)\
-: NanAsyncWorker(callback), lp(lp), file(file){\
+NAME##Worker(Nan::Callback *callback, CLASS *lp, std::string file)\
+: Nan::AsyncWorker(callback), lp(lp), file(file){\
     \
 }\
 \
@@ -361,16 +363,16 @@ void Execute () {\
     try {\
         ret = API(lp->handle, file.c_str());\
     } catch (std::string s) {\
-        NanThrowError(s.c_str());\
+        Nan::ThrowError(s.c_str());\
     }\
 }\
 void WorkComplete() {\
     lp->thread = false;\
-    NanAsyncWorker::WorkComplete();\
+    Nan::AsyncWorker::WorkComplete();\
 }\
 virtual void HandleOKCallback() {\
-    Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};\
-    callback->Call(2, args);\
+    Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};\
+    callback->Call(2, info);\
 }\
 \
 public:\
@@ -380,44 +382,44 @@ public:\
 };\
 \
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 2, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsString() || !args[1]->IsFunction(), "Wrong arguments");\
+    V8CHECK(info.Length() != 2, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsString() || !info[1]->IsFunction(), "Wrong arguments");\
     \
-    CLASS* lp = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* lp = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!lp->handle, "object deleted");\
     V8CHECK(lp->thread, "an async operation is inprogress")\
     \
-    NanCallback *callback = new NanCallback(args[1].As<Function>());\
-    NAME##Worker *worker = new NAME##Worker(callback, lp, V8TOCSTRING(args[0]));\
+    Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());\
+    NAME##Worker *worker = new NAME##Worker(callback, lp, V8TOCSTRING(info[0]));\
     lp->thread = true;\
-    NanAsyncQueueWorker(worker);\
-    NanReturnUndefined();\
+    Nan::AsyncQueueWorker(worker);\
+    return;\
 }\
 
 #define GLP_ASYNC_INT32_INT32_STR(CLASS, NAME, API)\
-class NAME##Worker : public NanAsyncWorker {\
+class NAME##Worker : public Nan::AsyncWorker {\
 public:\
-    NAME##Worker(NanCallback *callback, CLASS *lp, int flags, std::string file)\
-    : NanAsyncWorker(callback), flags(flags), lp(lp), file(file){\
+    NAME##Worker(Nan::Callback *callback, CLASS *lp, int flags, std::string file)\
+    : Nan::AsyncWorker(callback), flags(flags), lp(lp), file(file){\
         \
     }\
     void WorkComplete() {\
         lp->thread = false;\
-        NanAsyncWorker::WorkComplete();\
+        Nan::AsyncWorker::WorkComplete();\
     }\
     void Execute () {\
         try {\
             ret = API(lp->handle, flags, file.c_str());\
         } catch (std::string s) {\
-            NanThrowError(s.c_str());\
+            Nan::ThrowError(s.c_str());\
         }\
     }\
     \
     virtual void HandleOKCallback() {\
-        Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};\
-        callback->Call(2, args);\
+        Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};\
+        callback->Call(2, info);\
     }\
     \
 public:\
@@ -427,37 +429,37 @@ public:\
 };\
 \
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 3, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsInt32() || !args[1]->IsString() || !args[2]->IsFunction(), "Wrong arguments");\
+    V8CHECK(info.Length() != 3, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsInt32() || !info[1]->IsString() || !info[2]->IsFunction(), "Wrong arguments");\
     \
-    CLASS* lp = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* lp = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!lp->handle, "object deleted");\
     V8CHECK(lp->thread, "an async operation is inprogress")\
     \
-    NanCallback *callback = new NanCallback(args[2].As<Function>());\
-    NAME##Worker *worker = new NAME##Worker(callback, lp, args[0]->Int32Value(), V8TOCSTRING(args[1]));\
+    Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());\
+    NAME##Worker *worker = new NAME##Worker(callback, lp, info[0]->Int32Value(), V8TOCSTRING(info[1]));\
     lp->thread = true;\
-    NanAsyncQueueWorker(worker);\
-    NanReturnUndefined();\
+    Nan::AsyncQueueWorker(worker);\
+    return;\
 }\
 
 #define GLP_ASYNC_VOID(CLASS, NAME, API)\
-class NAME##Worker : public NanAsyncWorker {\
+class NAME##Worker : public Nan::AsyncWorker {\
 public:\
-    NAME##Worker(NanCallback *callback, CLASS *lp)\
-    : NanAsyncWorker(callback), lp(lp) {\
+    NAME##Worker(Nan::Callback *callback, CLASS *lp)\
+    : Nan::AsyncWorker(callback), lp(lp) {\
     }\
     void WorkComplete() {\
         lp->thread = false;\
-        NanAsyncWorker::WorkComplete();\
+        Nan::AsyncWorker::WorkComplete();\
     }\
     void Execute () {\
         try {\
             API(lp->handle);\
         } catch (std::string s) {\
-            NanThrowError(s.c_str());\
+            Nan::ThrowError(s.c_str());\
         }\
     }\
 public:\
@@ -465,20 +467,20 @@ public:\
 };\
 \
 static NAN_METHOD(NAME) {\
-    NanScope();\
+    Nan::HandleScope scope;\
     \
-    V8CHECK(args.Length() != 1, "Wrong number of arguments");\
-    V8CHECK(!args[0]->IsFunction(), "Wrong arguments");\
+    V8CHECK(info.Length() != 1, "Wrong number of arguments");\
+    V8CHECK(!info[0]->IsFunction(), "Wrong arguments");\
     \
-    CLASS* lp = ObjectWrap::Unwrap<CLASS>(args.Holder());\
+    CLASS* lp = Nan::ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!lp->handle, "object deleted");\
     V8CHECK(lp->thread, "an async operation is inprogress")\
     \
-    NanCallback *callback = new NanCallback(args[0].As<Function>());\
+    Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());\
     NAME##Worker *worker = new NAME##Worker(callback, lp);\
     lp->thread = true;\
-    NanAsyncQueueWorker(worker);\
-    NanReturnUndefined();\
+    Nan::AsyncQueueWorker(worker);\
+    return;\
 }\
 
 

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -9,34 +9,34 @@ namespace NodeGLPK {
     
     using namespace v8;
 
-    class Mathprog : public node::ObjectWrap {
+    class Mathprog : public Nan::ObjectWrap {
     public:
         static void Init(Handle<Object> exports){
             // Prepare constructor template
-            Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(New);
-            tpl->SetClassName(NanNew<String>("Mathprog"));
+            Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+            tpl->SetClassName(Nan::New<String>("Mathprog").ToLocalChecked());
             tpl->InstanceTemplate()->SetInternalFieldCount(1);
  
             // prototypes
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readModelSync", ReadModelSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readModel", ReadModel);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readDataSync", ReadDataSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readData", ReadData);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "generateSync", GenerateSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "generate", Generate);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "delete", Delete);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "buildProbSync", BuildProbSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "buildProb", BuildProb);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "postsolveSync", PostsolveSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "postsolve", Postsolve);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getLine", getLine);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getLastError", getLastError);
+            Nan::SetPrototypeMethod(tpl, "readModelSync", ReadModelSync);
+            Nan::SetPrototypeMethod(tpl, "readModel", ReadModel);
+            Nan::SetPrototypeMethod(tpl, "readDataSync", ReadDataSync);
+            Nan::SetPrototypeMethod(tpl, "readData", ReadData);
+            Nan::SetPrototypeMethod(tpl, "generateSync", GenerateSync);
+            Nan::SetPrototypeMethod(tpl, "generate", Generate);
+            Nan::SetPrototypeMethod(tpl, "delete", Delete);
+            Nan::SetPrototypeMethod(tpl, "buildProbSync", BuildProbSync);
+            Nan::SetPrototypeMethod(tpl, "buildProb", BuildProb);
+            Nan::SetPrototypeMethod(tpl, "postsolveSync", PostsolveSync);
+            Nan::SetPrototypeMethod(tpl, "postsolve", Postsolve);
+            Nan::SetPrototypeMethod(tpl, "getLine", getLine);
+            Nan::SetPrototypeMethod(tpl, "getLastError", getLastError);
             
-            NanAssignPersistent(constructor, tpl);
-            exports->Set(NanNew<String>("Mathprog"), tpl->GetFunction());
+            constructor.Reset(v8::Isolate::GetCurrent(), tpl);
+            exports->Set(Nan::New<String>("Mathprog").ToLocalChecked(), tpl->GetFunction());
         }
     private:
-        explicit Mathprog(): node::ObjectWrap(){
+        explicit Mathprog(): Nan::ObjectWrap(){
             handle = glp_mpl_alloc_wksp();
             thread = false;
         };
@@ -45,27 +45,27 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(New){
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(!args.IsConstructCall(), "Constructor Mathprog requires 'new'");
+            V8CHECK(!info.IsConstructCall(), "Constructor Mathprog requires 'new'");
             
             GLP_CATCH_RET(
                 Mathprog* obj = new Mathprog();
-                obj->Wrap(args.This());
-                      NanReturnValue(args.This());
+                obj->Wrap(info.This());
+                      info.GetReturnValue().Set(info.This());
             );
         }
         
         
-        class ReadModelWorker : public NanAsyncWorker {
+        class ReadModelWorker : public Nan::AsyncWorker {
         public:
-            ReadModelWorker(NanCallback *callback, Mathprog *mp, char *file, int parm)
-            : NanAsyncWorker(callback), mp(mp), file(file), parm(parm){
+            ReadModelWorker(Nan::Callback *callback, Mathprog *mp, char *file, int parm)
+            : Nan::AsyncWorker(callback), mp(mp), file(file), parm(parm){
                 
             }
             void WorkComplete() {
                 mp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -75,8 +75,8 @@ namespace NodeGLPK {
                 }
             }
             virtual void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
             public:
                 Mathprog *mp;
@@ -85,33 +85,33 @@ namespace NodeGLPK {
             };
 
         static NAN_METHOD(ReadModel) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 3, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsString() || !args[1]->IsInt32() || !args[2]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 3, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsString() || !info[1]->IsInt32() || !info[2]->IsFunction(), "Wrong arguments");
         
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[2].As<Function>());
-            ReadModelWorker *worker = new ReadModelWorker(callback, mp, V8TOCSTRING(args[0]), args[1]->Int32Value());
+            Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());
+            ReadModelWorker *worker = new ReadModelWorker(callback, mp, V8TOCSTRING(info[0]), info[1]->Int32Value());
             mp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
   
         GLP_BIND_VALUE_STR_INT32(Mathprog, ReadModelSync, glp_mpl_read_model);
         
-        class ReadDataWorker : public NanAsyncWorker {
+        class ReadDataWorker : public Nan::AsyncWorker {
         public:
-            ReadDataWorker(NanCallback *callback, Mathprog *mp, char *file)
-            : NanAsyncWorker(callback), mp(mp), file(file){
+            ReadDataWorker(Nan::Callback *callback, Mathprog *mp, char *file)
+            : Nan::AsyncWorker(callback), mp(mp), file(file){
                 
             }
             void WorkComplete() {
                 mp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -121,8 +121,8 @@ namespace NodeGLPK {
                 }
             }
             virtual void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
         public:
             Mathprog *mp;
@@ -131,33 +131,33 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(ReadData) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsString() || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsString() || !info[1]->IsFunction(), "Wrong arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
-            ReadDataWorker *worker = new ReadDataWorker(callback, mp, V8TOCSTRING(args[0]));
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
+            ReadDataWorker *worker = new ReadDataWorker(callback, mp, V8TOCSTRING(info[0]));
             mp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         GLP_BIND_VALUE_STR(Mathprog, ReadDataSync, glp_mpl_read_data);
         
-        class GenerateWorker : public NanAsyncWorker {
+        class GenerateWorker : public Nan::AsyncWorker {
         public:
-            GenerateWorker(NanCallback *callback, Mathprog *mp, char *file)
-            : NanAsyncWorker(callback), mp(mp){
+            GenerateWorker(Nan::Callback *callback, Mathprog *mp, char *file)
+            : Nan::AsyncWorker(callback), mp(mp){
                 if (file) this->file = file;
             }
             void WorkComplete() {
                 mp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -170,8 +170,8 @@ namespace NodeGLPK {
                 }
             }
             virtual void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
             
         public:
@@ -181,53 +181,53 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Generate) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsString() || args[0]->IsNull()) || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsString() || info[0]->IsNull()) || !info[1]->IsFunction(), "Wrong arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             GenerateWorker *worker = NULL;
-            if (args[0]->IsString())
-                worker = new GenerateWorker(callback, mp, V8TOCSTRING(args[0]));
+            if (info[0]->IsString())
+                worker = new GenerateWorker(callback, mp, V8TOCSTRING(info[0]));
             else
                 worker = new GenerateWorker(callback, mp, NULL);
             mp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(GenerateSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() > 1, "Wrong number of arguments");
+            V8CHECK(info.Length() > 1, "Wrong number of arguments");
 
-            Mathprog* host = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* host = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread, "an async operation is inprogress");
             
             GLP_CATCH_RET(
-                if ((args.Length() == 1) && (!args[0]->IsString()))
-                    NanReturnValue(glp_mpl_generate(host->handle, V8TOCSTRING(args[0])));
+                if ((info.Length() == 1) && (!info[0]->IsString()))
+                    info.GetReturnValue().Set(glp_mpl_generate(host->handle, V8TOCSTRING(info[0])));
                 else
-                    NanReturnValue(glp_mpl_generate(host->handle, NULL));
+                    info.GetReturnValue().Set(glp_mpl_generate(host->handle, NULL));
             )
         }
         
-        class BuildProbWorker : public NanAsyncWorker {
+        class BuildProbWorker : public Nan::AsyncWorker {
         public:
-            BuildProbWorker(NanCallback *callback, Mathprog *mp, Problem *lp)
-            : NanAsyncWorker(callback), mp(mp), lp(lp){
+            BuildProbWorker(Nan::Callback *callback, Mathprog *mp, Problem *lp)
+            : Nan::AsyncWorker(callback), mp(mp), lp(lp){
                 
             }
             void WorkComplete() {
                 mp->thread = false;
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -242,54 +242,54 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(BuildProb) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsObject() || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsObject() || !info[1]->IsFunction(), "Wrong arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args[0]->ToObject());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             BuildProbWorker *worker = new BuildProbWorker(callback, mp, lp);
             mp->thread = true;
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(BuildProbSync){
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 1, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsObject(), "Wrong arguments");
+            V8CHECK(info.Length() != 1, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsObject(), "Wrong arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args[0]->ToObject());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             
             GLP_CATCH_RET(glp_mpl_build_prob(mp->handle, lp->handle);)
         }
 
-        class PostsolveWorker : public NanAsyncWorker {
+        class PostsolveWorker : public Nan::AsyncWorker {
         public:
-            PostsolveWorker(NanCallback *callback, Mathprog *mp, Problem *lp, int parm)
-            : NanAsyncWorker(callback), mp(mp), lp(lp), parm(parm){
+            PostsolveWorker(Nan::Callback *callback, Mathprog *mp, Problem *lp, int parm)
+            : Nan::AsyncWorker(callback), mp(mp), lp(lp), parm(parm){
                 
             }
             void WorkComplete() {
                 mp->thread = false;
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -299,8 +299,8 @@ namespace NodeGLPK {
                 }
             }
             virtual void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
         public:
             Mathprog *mp;
@@ -309,67 +309,67 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Postsolve) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 3, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsObject() || !args[1]->IsInt32() || !args[2]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 3, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsObject() || !info[1]->IsInt32() || !info[2]->IsFunction(), "Wrong arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args[0]->ToObject());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[2].As<Function>());
-            PostsolveWorker *worker = new PostsolveWorker(callback, mp, lp, args[1]->Int32Value());
+            Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());
+            PostsolveWorker *worker = new PostsolveWorker(callback, mp, lp, info[1]->Int32Value());
             mp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(PostsolveSync){
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsObject() || !args[1]->IsInt32(), "Wrong arguments");
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsObject() || !info[1]->IsInt32(), "Wrong arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args[0]->ToObject());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             
-            GLP_CATCH_RET(NanReturnValue(glp_mpl_postsolve(mp->handle, lp->handle, args[1]->Int32Value()));)
+            GLP_CATCH_RET(info.GetReturnValue().Set(glp_mpl_postsolve(mp->handle, lp->handle, info[1]->Int32Value()));)
         }
         
         static NAN_METHOD(getLine){
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 0, "Wrong number of arguments");
+            V8CHECK(info.Length() != 0, "Wrong number of arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             
-            NanReturnValue(*(int*)mp->handle);
+            info.GetReturnValue().Set(*(int*)mp->handle);
         }
         
         static NAN_METHOD(getLastError){
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 0, "Wrong number of arguments");
+            V8CHECK(info.Length() != 0, "Wrong number of arguments");
             
-            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(args.Holder());
+            Mathprog* mp = Nan::ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread, "an async operation is inprogress");
             char * msg = glp_mpl_getlasterror(mp->handle);
             if (msg)
-                NanReturnValue(NanNew<String>(msg));
+                info.GetReturnValue().Set(Nan::New<String>(msg).ToLocalChecked());
             else
-                NanReturnValue(NanNull());
+                info.GetReturnValue().Set(Nan::Null());
         }
         
         GLP_BIND_DELETE(Mathprog, Delete, glp_mpl_free_wksp);

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -21,11 +21,11 @@ extern "C" {
     }
 
     NAN_METHOD(TermOutput) {
-        NanScope();
-        V8CHECK(args.Length() != 1, "Wrong number of arguments");
-        V8CHECK(!args[0]->IsBoolean(), "Wrong arguments");
+        Nan::HandleScope scope;
+        V8CHECK(info.Length() != 1, "Wrong number of arguments");
+        V8CHECK(!info[0]->IsBoolean(), "Wrong arguments");
         
-        if (args[0]->BooleanValue()) {
+        if (info[0]->BooleanValue()) {
             GLP_CATCH_RET(glp_term_hook(_TermHook);)
         } else {
             GLP_CATCH_RET(glp_term_hook(NULL);)
@@ -35,7 +35,7 @@ extern "C" {
     void Init(Handle<Object> exports) {
         glp_error_hook(_ErrorHook);
 
-        exports->Set(NanNew<String>("termOutput"), NanNew<FunctionTemplate>(TermOutput)->GetFunction());
+        exports->Set(Nan::New<String>("termOutput").ToLocalChecked(), Nan::New<FunctionTemplate>(TermOutput)->GetFunction());
         
         GLP_DEFINE_CONSTANT(exports, GLP_MAJOR_VERSION, MAJOR_VERSION);
         GLP_DEFINE_CONSTANT(exports, GLP_MINOR_VERSION, MINOR_VERSION);

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -11,147 +11,147 @@ namespace NodeGLPK {
     
     using namespace v8;
     
-    class Problem : public node::ObjectWrap {
+    class Problem : public Nan::ObjectWrap {
     public:
         static void Init(Handle<Object> exports){
             // Prepare constructor template
-            Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(New);
-            tpl->SetClassName(NanNew<String>("Problem"));
+            Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+            tpl->SetClassName(Nan::New<String>("Problem").ToLocalChecked());
             tpl->InstanceTemplate()->SetInternalFieldCount(1);
             
             // Prototype
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setProbName", SetProbName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getProbName", GetProbName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setObjDir", SetObjDir);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getObjDir", GetObjDir);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "addRows", AddRows);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setRowName", SetRowName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowName", GetRowName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setRowBnds", SetRowBnds);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "addCols", AddCols);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setColName", SetColName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColName", GetColName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setColBnds", SetColBnds);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setObjCoef", SetObjCoef);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getObjCoef", GetObjCoef);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "loadMatrix", LoadMatrix);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "simplexSync", SimplexSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "simplex", Simplex);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getObjVal", GetObjVal);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColPrim", GetColPrim);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setObjName", SetObjName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getObjName", GetObjName);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setMatRow", SetMatRow);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getMatRow", GetMatRow);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setMatCol", SetMatCol);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getMatCol", GetMatCol);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "sortMatrix", SortMatrix);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "delRows", DelRows);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "delCols", DelCols);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "erase", Erase);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "delete", Delete);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getNumRows", GetNumRows);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getNumCols", GetNumCols);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowType", GetRowType);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowLb", GetRowLb);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowUb", GetRowUb);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColType", GetColType);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColLb", GetColLb);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColUb", GetColUb);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getNumNz", GetNumNz);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "createIndex", CreateIndex);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "findRow", FindRow);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "findCol", FindCol);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "deleteIndex", DeleteIndex);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setRii", SetRii);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setSjj", SetSjj);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRii", GetRii);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getSjj", GetSjj);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "scaleSync", ScaleSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "scale", Scale);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "unscaleSync", UnscaleSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "unscale", Unscale);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setRowStat", SetRowStat);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setColStat", SetColStat);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowStat", GetRowStat);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColStat", GetColStat);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "stdBasis", StdBasis);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "advBasis", AdvBasis);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "cpxBasis", CpxBasis);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "exactSync", ExactSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "exact", Exact);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getStatus", GetStatus);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getPrimStat", GetPrimStat);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getDualStat", GetDualStat);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowPrim", GetRowPrim);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowDual", GetRowDual);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColDual", GetColDual);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getUnbndRay", GetUnbndRay);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getItCnt", GetItCnt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setItCnt", SetItCnt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "interiorSync", InteriorSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "interior", Interior);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "iptStatus", IptStatus);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readMpsSync", ReadMpsSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readMps", ReadMps);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeMpsSync", WriteMpsSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeMps", WriteMps);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "iptObjVal", IptObjVal);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "iptRowPrim", IptRowPrim);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "iptRowDual", IptRowDual);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "iptColPrim", IptColPrim);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "iptColDual", IptColDual);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setColKind", SetColKind);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColKind", GetColKind);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getNumInt", GetNumInt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getNumBin", GetNumBin);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "intoptSync", IntoptSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "intopt", Intopt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readProbSync", ReadProbSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readProb", ReadProb);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeProbSync", WriteProbSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeProb", WriteProb);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readLp", ReadLp);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readLpSync", ReadLpSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeLpSync", WriteLpSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeLp", WriteLp);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "mipStatus", MipStatus);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "mipObjVal", MipObjVal);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "mipRowVal", MipRowVal);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "mipColVal", MipColVal);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "checkKkt", CheckKkt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printSolSync", PrintSolSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printSol", PrintSol);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readSolSync", ReadSolSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readSol", ReadSol);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeSolSync", WriteSolSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeSol", WriteSol);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printRangesSync", PrintRangesSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printRanges", PrintRanges);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printIptSync", PrintIptSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printIpt", PrintIpt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readIptSync", ReadIptSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readIpt", ReadIpt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeIptSync", WriteIptSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeIpt", WriteIpt);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printMipSync", PrintMipSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "printMip", PrintMip);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readMipSync", ReadMipSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "readMip", ReadMip);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeMipSync", WriteMipSync);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "writeMip", WriteMip);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "bfExists", BfExists);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "factorize", Factorize);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "bfUpdated", BfUpdated);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getBfcp", GetBfcp);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "setBfcp", SetBfcp);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getBhead", GetBhead);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getRowBind", GetRowBind);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "getColBind", GetColBind);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "warmUp", WarmUp);
+            Nan::SetPrototypeMethod(tpl, "setProbName", SetProbName);
+            Nan::SetPrototypeMethod(tpl, "getProbName", GetProbName);
+            Nan::SetPrototypeMethod(tpl, "setObjDir", SetObjDir);
+            Nan::SetPrototypeMethod(tpl, "getObjDir", GetObjDir);
+            Nan::SetPrototypeMethod(tpl, "addRows", AddRows);
+            Nan::SetPrototypeMethod(tpl, "setRowName", SetRowName);
+            Nan::SetPrototypeMethod(tpl, "getRowName", GetRowName);
+            Nan::SetPrototypeMethod(tpl, "setRowBnds", SetRowBnds);
+            Nan::SetPrototypeMethod(tpl, "addCols", AddCols);
+            Nan::SetPrototypeMethod(tpl, "setColName", SetColName);
+            Nan::SetPrototypeMethod(tpl, "getColName", GetColName);
+            Nan::SetPrototypeMethod(tpl, "setColBnds", SetColBnds);
+            Nan::SetPrototypeMethod(tpl, "setObjCoef", SetObjCoef);
+            Nan::SetPrototypeMethod(tpl, "getObjCoef", GetObjCoef);
+            Nan::SetPrototypeMethod(tpl, "loadMatrix", LoadMatrix);
+            Nan::SetPrototypeMethod(tpl, "simplexSync", SimplexSync);
+            Nan::SetPrototypeMethod(tpl, "simplex", Simplex);
+            Nan::SetPrototypeMethod(tpl, "getObjVal", GetObjVal);
+            Nan::SetPrototypeMethod(tpl, "getColPrim", GetColPrim);
+            Nan::SetPrototypeMethod(tpl, "setObjName", SetObjName);
+            Nan::SetPrototypeMethod(tpl, "getObjName", GetObjName);
+            Nan::SetPrototypeMethod(tpl, "setMatRow", SetMatRow);
+            Nan::SetPrototypeMethod(tpl, "getMatRow", GetMatRow);
+            Nan::SetPrototypeMethod(tpl, "setMatCol", SetMatCol);
+            Nan::SetPrototypeMethod(tpl, "getMatCol", GetMatCol);
+            Nan::SetPrototypeMethod(tpl, "sortMatrix", SortMatrix);
+            Nan::SetPrototypeMethod(tpl, "delRows", DelRows);
+            Nan::SetPrototypeMethod(tpl, "delCols", DelCols);
+            Nan::SetPrototypeMethod(tpl, "erase", Erase);
+            Nan::SetPrototypeMethod(tpl, "delete", Delete);
+            Nan::SetPrototypeMethod(tpl, "getNumRows", GetNumRows);
+            Nan::SetPrototypeMethod(tpl, "getNumCols", GetNumCols);
+            Nan::SetPrototypeMethod(tpl, "getRowType", GetRowType);
+            Nan::SetPrototypeMethod(tpl, "getRowLb", GetRowLb);
+            Nan::SetPrototypeMethod(tpl, "getRowUb", GetRowUb);
+            Nan::SetPrototypeMethod(tpl, "getColType", GetColType);
+            Nan::SetPrototypeMethod(tpl, "getColLb", GetColLb);
+            Nan::SetPrototypeMethod(tpl, "getColUb", GetColUb);
+            Nan::SetPrototypeMethod(tpl, "getNumNz", GetNumNz);
+            Nan::SetPrototypeMethod(tpl, "createIndex", CreateIndex);
+            Nan::SetPrototypeMethod(tpl, "findRow", FindRow);
+            Nan::SetPrototypeMethod(tpl, "findCol", FindCol);
+            Nan::SetPrototypeMethod(tpl, "deleteIndex", DeleteIndex);
+            Nan::SetPrototypeMethod(tpl, "setRii", SetRii);
+            Nan::SetPrototypeMethod(tpl, "setSjj", SetSjj);
+            Nan::SetPrototypeMethod(tpl, "getRii", GetRii);
+            Nan::SetPrototypeMethod(tpl, "getSjj", GetSjj);
+            Nan::SetPrototypeMethod(tpl, "scaleSync", ScaleSync);
+            Nan::SetPrototypeMethod(tpl, "scale", Scale);
+            Nan::SetPrototypeMethod(tpl, "unscaleSync", UnscaleSync);
+            Nan::SetPrototypeMethod(tpl, "unscale", Unscale);
+            Nan::SetPrototypeMethod(tpl, "setRowStat", SetRowStat);
+            Nan::SetPrototypeMethod(tpl, "setColStat", SetColStat);
+            Nan::SetPrototypeMethod(tpl, "getRowStat", GetRowStat);
+            Nan::SetPrototypeMethod(tpl, "getColStat", GetColStat);
+            Nan::SetPrototypeMethod(tpl, "stdBasis", StdBasis);
+            Nan::SetPrototypeMethod(tpl, "advBasis", AdvBasis);
+            Nan::SetPrototypeMethod(tpl, "cpxBasis", CpxBasis);
+            Nan::SetPrototypeMethod(tpl, "exactSync", ExactSync);
+            Nan::SetPrototypeMethod(tpl, "exact", Exact);
+            Nan::SetPrototypeMethod(tpl, "getStatus", GetStatus);
+            Nan::SetPrototypeMethod(tpl, "getPrimStat", GetPrimStat);
+            Nan::SetPrototypeMethod(tpl, "getDualStat", GetDualStat);
+            Nan::SetPrototypeMethod(tpl, "getRowPrim", GetRowPrim);
+            Nan::SetPrototypeMethod(tpl, "getRowDual", GetRowDual);
+            Nan::SetPrototypeMethod(tpl, "getColDual", GetColDual);
+            Nan::SetPrototypeMethod(tpl, "getUnbndRay", GetUnbndRay);
+            Nan::SetPrototypeMethod(tpl, "getItCnt", GetItCnt);
+            Nan::SetPrototypeMethod(tpl, "setItCnt", SetItCnt);
+            Nan::SetPrototypeMethod(tpl, "interiorSync", InteriorSync);
+            Nan::SetPrototypeMethod(tpl, "interior", Interior);
+            Nan::SetPrototypeMethod(tpl, "iptStatus", IptStatus);
+            Nan::SetPrototypeMethod(tpl, "readMpsSync", ReadMpsSync);
+            Nan::SetPrototypeMethod(tpl, "readMps", ReadMps);
+            Nan::SetPrototypeMethod(tpl, "writeMpsSync", WriteMpsSync);
+            Nan::SetPrototypeMethod(tpl, "writeMps", WriteMps);
+            Nan::SetPrototypeMethod(tpl, "iptObjVal", IptObjVal);
+            Nan::SetPrototypeMethod(tpl, "iptRowPrim", IptRowPrim);
+            Nan::SetPrototypeMethod(tpl, "iptRowDual", IptRowDual);
+            Nan::SetPrototypeMethod(tpl, "iptColPrim", IptColPrim);
+            Nan::SetPrototypeMethod(tpl, "iptColDual", IptColDual);
+            Nan::SetPrototypeMethod(tpl, "setColKind", SetColKind);
+            Nan::SetPrototypeMethod(tpl, "getColKind", GetColKind);
+            Nan::SetPrototypeMethod(tpl, "getNumInt", GetNumInt);
+            Nan::SetPrototypeMethod(tpl, "getNumBin", GetNumBin);
+            Nan::SetPrototypeMethod(tpl, "intoptSync", IntoptSync);
+            Nan::SetPrototypeMethod(tpl, "intopt", Intopt);
+            Nan::SetPrototypeMethod(tpl, "readProbSync", ReadProbSync);
+            Nan::SetPrototypeMethod(tpl, "readProb", ReadProb);
+            Nan::SetPrototypeMethod(tpl, "writeProbSync", WriteProbSync);
+            Nan::SetPrototypeMethod(tpl, "writeProb", WriteProb);
+            Nan::SetPrototypeMethod(tpl, "readLp", ReadLp);
+            Nan::SetPrototypeMethod(tpl, "readLpSync", ReadLpSync);
+            Nan::SetPrototypeMethod(tpl, "writeLpSync", WriteLpSync);
+            Nan::SetPrototypeMethod(tpl, "writeLp", WriteLp);
+            Nan::SetPrototypeMethod(tpl, "mipStatus", MipStatus);
+            Nan::SetPrototypeMethod(tpl, "mipObjVal", MipObjVal);
+            Nan::SetPrototypeMethod(tpl, "mipRowVal", MipRowVal);
+            Nan::SetPrototypeMethod(tpl, "mipColVal", MipColVal);
+            Nan::SetPrototypeMethod(tpl, "checkKkt", CheckKkt);
+            Nan::SetPrototypeMethod(tpl, "printSolSync", PrintSolSync);
+            Nan::SetPrototypeMethod(tpl, "printSol", PrintSol);
+            Nan::SetPrototypeMethod(tpl, "readSolSync", ReadSolSync);
+            Nan::SetPrototypeMethod(tpl, "readSol", ReadSol);
+            Nan::SetPrototypeMethod(tpl, "writeSolSync", WriteSolSync);
+            Nan::SetPrototypeMethod(tpl, "writeSol", WriteSol);
+            Nan::SetPrototypeMethod(tpl, "printRangesSync", PrintRangesSync);
+            Nan::SetPrototypeMethod(tpl, "printRanges", PrintRanges);
+            Nan::SetPrototypeMethod(tpl, "printIptSync", PrintIptSync);
+            Nan::SetPrototypeMethod(tpl, "printIpt", PrintIpt);
+            Nan::SetPrototypeMethod(tpl, "readIptSync", ReadIptSync);
+            Nan::SetPrototypeMethod(tpl, "readIpt", ReadIpt);
+            Nan::SetPrototypeMethod(tpl, "writeIptSync", WriteIptSync);
+            Nan::SetPrototypeMethod(tpl, "writeIpt", WriteIpt);
+            Nan::SetPrototypeMethod(tpl, "printMipSync", PrintMipSync);
+            Nan::SetPrototypeMethod(tpl, "printMip", PrintMip);
+            Nan::SetPrototypeMethod(tpl, "readMipSync", ReadMipSync);
+            Nan::SetPrototypeMethod(tpl, "readMip", ReadMip);
+            Nan::SetPrototypeMethod(tpl, "writeMipSync", WriteMipSync);
+            Nan::SetPrototypeMethod(tpl, "writeMip", WriteMip);
+            Nan::SetPrototypeMethod(tpl, "bfExists", BfExists);
+            Nan::SetPrototypeMethod(tpl, "factorize", Factorize);
+            Nan::SetPrototypeMethod(tpl, "bfUpdated", BfUpdated);
+            Nan::SetPrototypeMethod(tpl, "getBfcp", GetBfcp);
+            Nan::SetPrototypeMethod(tpl, "setBfcp", SetBfcp);
+            Nan::SetPrototypeMethod(tpl, "getBhead", GetBhead);
+            Nan::SetPrototypeMethod(tpl, "getRowBind", GetRowBind);
+            Nan::SetPrototypeMethod(tpl, "getColBind", GetColBind);
+            Nan::SetPrototypeMethod(tpl, "warmUp", WarmUp);
             
-            NanAssignPersistent(constructor, tpl);
-            exports->Set(NanNew<String>("Problem"), tpl->GetFunction());
+            constructor.Reset(v8::Isolate::GetCurrent(), tpl);
+            exports->Set(Nan::New<String>("Problem").ToLocalChecked(), tpl->GetFunction());
         }
         
         static bool SmcpInit(glp_smcp* scmp, Local<Value> value){
@@ -213,7 +213,7 @@ namespace NodeGLPK {
             return true;
         }
     private:
-        explicit Problem(): node::ObjectWrap(){
+        explicit Problem(): Nan::ObjectWrap(){
             handle = glp_create_prob();
             thread = false;
         }
@@ -223,26 +223,26 @@ namespace NodeGLPK {
         }
         
         static NAN_METHOD(New) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(!args.IsConstructCall(), "Constructor Problem requires 'new'");
+            V8CHECK(!info.IsConstructCall(), "Constructor Problem requires 'new'");
             
             GLP_CATCH_RET(Problem* obj = new Problem();
-                      obj->Wrap(args.This());
-                      NanReturnValue(args.This());
+                      obj->Wrap(info.This());
+                      info.GetReturnValue().Set(info.This());
             )
         }
 
         static NAN_METHOD(LoadMatrix) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 4, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32() || !args[1]->IsInt32Array()
-                    || !args[2]->IsInt32Array() || !args[3]->IsFloat64Array(), "Wrong arguments");
+            V8CHECK(info.Length() != 4, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32() || !info[1]->IsInt32Array()
+                    || !info[2]->IsInt32Array() || !info[3]->IsFloat64Array(), "Wrong arguments");
             
-            Local<Int32Array> ia = Local<Int32Array>::Cast(args[1]);
-            Local<Int32Array> ja = Local<Int32Array>::Cast(args[2]);
-            Local<Float64Array> ar = Local<Float64Array>::Cast(args[3]);
+            Local<Int32Array> ia = Local<Int32Array>::Cast(info[1]);
+            Local<Int32Array> ja = Local<Int32Array>::Cast(info[2]);
+            Local<Float64Array> ar = Local<Float64Array>::Cast(info[3]);
             
             int* pia = new int[ia->Length()];
             int* pja = new int[ja->Length()];
@@ -252,11 +252,11 @@ namespace NodeGLPK {
             for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();
             for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            GLP_CATCH(glp_load_matrix(lp->handle, args[0]->Int32Value(), pia, pja, par);)
+            GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(), pia, pja, par);)
             
             delete[] pia;
             delete[] pja;
@@ -264,17 +264,17 @@ namespace NodeGLPK {
         }
 
         static NAN_METHOD(SimplexSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() > 1, "Wrong number of arguments");
+            V8CHECK(info.Length() > 1, "Wrong number of arguments");
             
             GLP_CATCH_RET(
                       glp_smcp scmp;
                       glp_init_smcp(&scmp);
-                      if (args.Length() == 1)
-                          if (!SmcpInit(&scmp, args[0])) return;
+                      if (info.Length() == 1)
+                          if (!SmcpInit(&scmp, info[0])) return;
                       
-                      Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+                      Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread, "an async operation is inprogress");
                       
@@ -282,15 +282,15 @@ namespace NodeGLPK {
             )
         }
         
-        class SimplexWorker : public NanAsyncWorker {
+        class SimplexWorker : public Nan::AsyncWorker {
         public:
-            SimplexWorker(NanCallback *callback, Problem *lp)
-            : NanAsyncWorker(callback), lp(lp){
+            SimplexWorker(Nan::Callback *callback, Problem *lp)
+            : Nan::AsyncWorker(callback), lp(lp){
                 glp_init_smcp(&smcp);
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -305,40 +305,40 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Simplex) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() > 2, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsObject() || args[0]->IsNull()) || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() > 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsObject() || info[0]->IsNull()) || !info[1]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             SimplexWorker *worker = new SimplexWorker(callback, lp);
-            if (!SmcpInit(&worker->smcp, args[0])){
+            if (!SmcpInit(&worker->smcp, info[0])){
                 worker->Destroy();
                 return;
             }
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(ExactSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() > 1, "Wrong number of arguments");
+            V8CHECK(info.Length() > 1, "Wrong number of arguments");
             
             GLP_CATCH_RET(
                       glp_smcp scmp;
                       glp_init_smcp(&scmp);
-                      if (args.Length() == 1) {
-                          if (args[0]->IsObject())
-                              if(!SmcpInit(&scmp, args[0])) return;
+                      if (info.Length() == 1) {
+                          if (info[0]->IsObject())
+                              if(!SmcpInit(&scmp, info[0])) return;
                       }
                       
-                      Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+                      Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread, "an async operation is inprogress");
                           
@@ -346,15 +346,15 @@ namespace NodeGLPK {
             )
         }
         
-        class ExactWorker : public NanAsyncWorker {
+        class ExactWorker : public Nan::AsyncWorker {
         public:
-            ExactWorker(NanCallback *callback, Problem *lp)
-            : NanAsyncWorker(callback), lp(lp){
+            ExactWorker(Nan::Callback *callback, Problem *lp)
+            : Nan::AsyncWorker(callback), lp(lp){
                 glp_init_smcp(&smcp);
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -369,24 +369,24 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Exact) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() > 2, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsObject() || args[0]->IsNull()) || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() > 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsObject() || info[0]->IsNull()) || !info[1]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             ExactWorker *worker = new ExactWorker(callback, lp);
-            if (!SmcpInit(&worker->smcp, args[0])){
+            if (!SmcpInit(&worker->smcp, info[0])){
                 worker->Destroy();
                 return;
             }
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static bool IptcpInit(glp_iptcp* iptcp, Local<Value> value){
@@ -413,17 +413,17 @@ namespace NodeGLPK {
         }
         
         static NAN_METHOD(InteriorSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() > 1, "Wrong number of arguments");
+            V8CHECK(info.Length() > 1, "Wrong number of arguments");
             
             GLP_CATCH_RET(
                       glp_iptcp iptcp;
                       glp_init_iptcp(&iptcp);
-                      if (args.Length() == 1)
-                         if (!IptcpInit(&iptcp, args[0])) return;
+                      if (info.Length() == 1)
+                         if (!IptcpInit(&iptcp, info[0])) return;
                       
-                      Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+                      Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread, "an async operation is inprogress");
                           
@@ -431,15 +431,15 @@ namespace NodeGLPK {
             )
         }
         
-        class InteriorWorker : public NanAsyncWorker {
+        class InteriorWorker : public Nan::AsyncWorker {
         public:
-            InteriorWorker(NanCallback *callback, Problem *lp)
-            : NanAsyncWorker(callback), lp(lp){
+            InteriorWorker(Nan::Callback *callback, Problem *lp)
+            : Nan::AsyncWorker(callback), lp(lp){
                 glp_init_iptcp(&iptcp);
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -455,24 +455,24 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Interior) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() > 2, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsObject() || args[0]->IsNull()) || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() > 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsObject() || info[0]->IsNull()) || !info[1]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             InteriorWorker *worker = new InteriorWorker(callback, lp);
-            if (!IptcpInit(&worker->iptcp, args[0])){
+            if (!IptcpInit(&worker->iptcp, info[0])){
                 worker->Destroy();
                 return;
             }
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static bool MpscpInit(glp_mpscp *mpscp, Local<Value> value){
@@ -505,31 +505,31 @@ namespace NodeGLPK {
         }
         
         static NAN_METHOD(ReadMpsSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 3, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32() || !(args[1]->IsObject() || args[1]->IsNull() || args[1]->IsUndefined()) || !args[2]->IsString(), "Wrong arguments");
+            V8CHECK(info.Length() != 3, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32() || !(info[1]->IsObject() || info[1]->IsNull() || info[1]->IsUndefined()) || !info[2]->IsString(), "Wrong arguments");
             
             GLP_CATCH_RET(
                 glp_mpscp mpscp;
                 glp_init_mpscp(&mpscp);
-                if (args.Length() == 1)
-                    if (!MpscpInit(&mpscp, args[0])) return;
+                if (info.Length() == 1)
+                    if (!MpscpInit(&mpscp, info[0])) return;
                       
-                Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+                Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
                 V8CHECK(!lp->handle, "object deleted");
                 V8CHECK(lp->thread, "an async operation is inprogress");
                           
-                int ret = glp_read_mps(lp->handle, args[0]->Int32Value(), &mpscp, V8TOCSTRING(args[2]));
+                int ret = glp_read_mps(lp->handle, info[0]->Int32Value(), &mpscp, V8TOCSTRING(info[2]));
                 if (mpscp.obj_name) delete[] mpscp.obj_name;
-                NanReturnValue(ret);
+                info.GetReturnValue().Set(ret);
             )
         }
         
-        class ReadMpsWorker : public NanAsyncWorker {
+        class ReadMpsWorker : public Nan::AsyncWorker {
         public:
-            ReadMpsWorker(NanCallback *callback, Problem *lp, int fmt, std::string file)
-            : NanAsyncWorker(callback), fmt(fmt), lp(lp), file(file){
+            ReadMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
+            : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
                 glp_init_mpscp(&mpscp);
             }
             
@@ -538,7 +538,7 @@ namespace NodeGLPK {
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -548,8 +548,8 @@ namespace NodeGLPK {
                 }
             }
             void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
             
         public:
@@ -560,52 +560,52 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(ReadMps) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 4, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32() || !(args[1]->IsObject() || args[1]->IsNull())
-                    || !args[2]->IsString() || !args[3]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 4, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32() || !(info[1]->IsObject() || info[1]->IsNull())
+                    || !info[2]->IsString() || !info[3]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[3].As<Function>());
-            ReadMpsWorker *worker = new ReadMpsWorker(callback, lp, args[0]->Int32Value(), V8TOCSTRING(args[2]));
-            if (!MpscpInit(&worker->mpscp, args[1])){
+            Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
+            ReadMpsWorker *worker = new ReadMpsWorker(callback, lp, info[0]->Int32Value(), V8TOCSTRING(info[2]));
+            if (!MpscpInit(&worker->mpscp, info[1])){
                 worker->Destroy();
                 return;
             }
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(WriteMpsSync) {
-            NanScope();
+            Nan::HandleScope scope;
             std::string objname;
             
-            V8CHECK(args.Length() != 3, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32() || !(args[1]->IsObject() || args[1]->IsNull() || args[1]->IsUndefined()) || !args[2]->IsString(), "Wrong arguments");
+            V8CHECK(info.Length() != 3, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32() || !(info[1]->IsObject() || info[1]->IsNull() || info[1]->IsUndefined()) || !info[2]->IsString(), "Wrong arguments");
             
             GLP_CATCH_RET(
               glp_mpscp mpscp;
               glp_init_mpscp(&mpscp);
-              if (args.Length() == 1)
-                if (!MpscpInit(&mpscp, args[0])) return;
+              if (info.Length() == 1)
+                if (!MpscpInit(&mpscp, info[0])) return;
               
-              Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+              Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
               V8CHECK(!lp->handle, "object deleted");
               V8CHECK(lp->thread, "an async operation is inprogress");
                           
-              NanReturnValue(glp_write_mps(lp->handle, args[0]->Int32Value(), &mpscp, V8TOCSTRING(args[2])));
+              info.GetReturnValue().Set(glp_write_mps(lp->handle, info[0]->Int32Value(), &mpscp, V8TOCSTRING(info[2])));
             )
         }
         
-        class WriteMpsWorker : public NanAsyncWorker {
+        class WriteMpsWorker : public Nan::AsyncWorker {
         public:
-            WriteMpsWorker(NanCallback *callback, Problem *lp, int fmt, std::string file)
-            : NanAsyncWorker(callback), fmt(fmt), lp(lp), file(file){
+            WriteMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
+            : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
                 glp_init_mpscp(&mpscp);
             }
             
@@ -614,7 +614,7 @@ namespace NodeGLPK {
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -624,8 +624,8 @@ namespace NodeGLPK {
                 }
             }
             void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
             
         public:
@@ -636,36 +636,36 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(WriteMps) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 4, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32() || !(args[1]->IsObject() || args[1]->IsNull())
-                    || !args[2]->IsString() || !args[3]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 4, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32() || !(info[1]->IsObject() || info[1]->IsNull())
+                    || !info[2]->IsString() || !info[3]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[3].As<Function>());
-            WriteMpsWorker *worker = new WriteMpsWorker(callback, lp, args[0]->Int32Value(), V8TOCSTRING(args[2]));
-            if (!MpscpInit(&worker->mpscp, args[1])){
+            Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
+            WriteMpsWorker *worker = new WriteMpsWorker(callback, lp, info[0]->Int32Value(), V8TOCSTRING(info[2]));
+            if (!MpscpInit(&worker->mpscp, info[1])){
                 worker->Destroy();
                 return;
             }
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         
         
         static void IocpCallback(glp_tree *T, void *info){
-            NanCallback* cb = (NanCallback*)info;
+            Nan::Callback* cb = (Nan::Callback*)info;
             const unsigned argc = 1;
             Local<Value> t = Tree::Instantiate(T);
-            Local<Value> argv[argc] = {NanNew<Value>(t)};
+            Local<Value> argv[argc] = {Nan::New<Value>(t)};
             cb->Call(argc, argv);
-            Tree* host = ObjectWrap::Unwrap<Tree>(t->ToObject());
+            Tree* host = Nan::ObjectWrap::Unwrap<Tree>(t->ToObject());
             host->thread = true;
             host->handle = NULL;
         };
@@ -750,7 +750,7 @@ namespace NodeGLPK {
                     } else if (keystr == "cbFunc"){
                         V8CHECKBOOL(!val->IsFunction(), "cbFunc: should be a function");
                         iocp->cb_func = IocpCallback;
-                        iocp->cb_info = new NanCallback(Local<Function>::Cast(val));
+                        iocp->cb_info = new Nan::Callback(Local<Function>::Cast(val));
                     } else if (keystr == "cbReasons"){
                         V8CHECKBOOL(!val->IsInt32(), "cbReason: should be int32");
                         iocp->cb_reasons = val->Int32Value();
@@ -765,29 +765,29 @@ namespace NodeGLPK {
         }
         
         static NAN_METHOD(IntoptSync) {
-            NanScope();
-            V8CHECK(args.Length() > 1, "Wrong number of arguments");
+            Nan::HandleScope scope;
+            V8CHECK(info.Length() > 1, "Wrong number of arguments");
             
             GLP_CATCH_RET(
                       glp_iocp iocp;
                       glp_init_iocp(&iocp);
-                      if (args.Length() == 1)
-                          if (!IocpInit(&iocp, args[0])) return;
+                      if (info.Length() == 1)
+                          if (!IocpInit(&iocp, info[0])) return;
                       
-                      Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+                      Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread, "an async operation is inprogress");
                           
                       glp_intopt(lp->handle, &iocp);
-                      if (iocp.cb_info) delete (NanCallback*)iocp.cb_info;
+                      if (iocp.cb_info) delete (Nan::Callback*)iocp.cb_info;
                       if (iocp.save_sol) delete[] iocp.save_sol;
             )
         }
         
-        class IntoptWorker : public NanAsyncWorker {
+        class IntoptWorker : public Nan::AsyncWorker {
         public:
-            IntoptWorker(NanCallback *callback, Problem *lp)
-            : NanAsyncWorker(callback), lp(lp){
+            IntoptWorker(Nan::Callback *callback, Problem *lp)
+            : Nan::AsyncWorker(callback), lp(lp){
                 glp_init_iocp(&parm);
                 glp_init_mip_ctx(&ctx);
                 ctx.parm = &parm;
@@ -795,7 +795,7 @@ namespace NodeGLPK {
             }
             
             ~IntoptWorker(){
-                if (parm.cb_info) delete (NanCallback*)parm.cb_info;
+                if (parm.cb_info) delete (Nan::Callback*)parm.cb_info;
                 if (parm.save_sol) delete[] parm.save_sol;
             }
             
@@ -814,7 +814,7 @@ namespace NodeGLPK {
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanScope();
+                Nan::HandleScope scope;
                 if (ctx.done) {
                     state = 2;
                     glp_intopt_stop(lp->handle, &ctx);
@@ -828,13 +828,13 @@ namespace NodeGLPK {
                 } else {
                     parm.cb_func(ctx.tree, parm.cb_info);
                     lp->thread = true;
-                    NanAsyncQueueWorker(this);
+                    Nan::AsyncQueueWorker(this);
                 }
             }
             
             void HandleOKCallback(){
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ctx.ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ctx.ret)};
+                callback->Call(2, info);
             }
             
             void Destroy() {
@@ -848,47 +848,47 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Intopt) {
-            NanScope();
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsObject() || args[0]->IsNull()) || !args[1]->IsFunction(), "Wrong arguments");
+            Nan::HandleScope scope;
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsObject() || info[0]->IsNull()) || !info[1]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             IntoptWorker *worker = new IntoptWorker(callback, lp);
-            if (!IocpInit(&worker->parm, args[0])){
+            if (!IocpInit(&worker->parm, info[0])){
                 worker->Destroy();
                 return;
             }
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(ReadLpSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 1, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsString(), "Wrong arguments");
+            V8CHECK(info.Length() != 1, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsString(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanReturnValue(glp_read_lp(lp->handle, NULL, V8TOCSTRING(args[0])));
+            info.GetReturnValue().Set(glp_read_lp(lp->handle, NULL, V8TOCSTRING(info[0])));
         }
         
-        class ReadLpWorker : public NanAsyncWorker {
+        class ReadLpWorker : public Nan::AsyncWorker {
         public:
-            ReadLpWorker(NanCallback *callback, Problem *lp, std::string file)
-            : NanAsyncWorker(callback), lp(lp), file(file){
+            ReadLpWorker(Nan::Callback *callback, Problem *lp, std::string file)
+            : Nan::AsyncWorker(callback), lp(lp), file(file){
                 
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -898,8 +898,8 @@ namespace NodeGLPK {
                 }
             }
             void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
             
         public:
@@ -909,44 +909,44 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(ReadLp) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsString() || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsString() || !info[1]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
-            ReadLpWorker *worker = new ReadLpWorker(callback, lp, V8TOCSTRING(args[0]));
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
+            ReadLpWorker *worker = new ReadLpWorker(callback, lp, V8TOCSTRING(info[0]));
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(WriteLpSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 1, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsString(), "Wrong arguments");
+            V8CHECK(info.Length() != 1, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsString(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            GLP_CATCH_RET(NanReturnValue(glp_write_lp(lp->handle, NULL, V8TOCSTRING(args[0])));)
+            GLP_CATCH_RET(info.GetReturnValue().Set(glp_write_lp(lp->handle, NULL, V8TOCSTRING(info[0])));)
         }
         
-        class WriteLpWorker : public NanAsyncWorker {
+        class WriteLpWorker : public Nan::AsyncWorker {
         public:
-            WriteLpWorker(NanCallback *callback, Problem *lp, std::string file)
-            : NanAsyncWorker(callback), lp(lp), file(file){
+            WriteLpWorker(Nan::Callback *callback, Problem *lp, std::string file)
+            : Nan::AsyncWorker(callback), lp(lp), file(file){
                 
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -956,8 +956,8 @@ namespace NodeGLPK {
                 }
             }
             void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
         public:
             int ret;
@@ -966,56 +966,56 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(WriteLp) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsString() || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsString() || !info[1]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
-            WriteLpWorker *worker = new WriteLpWorker(callback, lp, V8TOCSTRING(args[0]));
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
+            WriteLpWorker *worker = new WriteLpWorker(callback, lp, V8TOCSTRING(info[0]));
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(CheckKkt) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 3, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32() || !args[1]->IsInt32() || !args[2]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 3, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32() || !info[1]->IsInt32() || !info[2]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             double ae_max, re_max;
             int ae_ind, re_ind;
-            GLP_CATCH_RET(glp_check_kkt(lp->handle, args[0]->Int32Value(), args[1]->Int32Value(), &ae_max, &ae_ind, &re_max, &re_ind);)
+            GLP_CATCH_RET(glp_check_kkt(lp->handle, info[0]->Int32Value(), info[1]->Int32Value(), &ae_max, &ae_ind, &re_max, &re_ind);)
             
-            NanCallback* cb = new NanCallback(Local<Function>::Cast(args[2]));
+            Nan::Callback* cb = new Nan::Callback(Local<Function>::Cast(info[2]));
             const unsigned argc = 4;
             Local<Value> argv[argc] = {
-                NanNew<Number>(ae_max),
-                NanNew<Int32>(ae_ind),
-                NanNew<Number>(re_max),
-                NanNew<Int32>(re_ind)
+                Nan::New<Number>(ae_max),
+                Nan::New<Int32>(ae_ind),
+                Nan::New<Number>(re_max),
+                Nan::New<Int32>(re_ind)
             };
             GLP_CATCH(cb->Call(argc, argv);)
             delete cb;
         }
         
         static NAN_METHOD(PrintRangesSync) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 3, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsInt32Array() || args[0]->IsNull() || args[0]->IsUndefined()) ||
-                !args[1]->IsInt32() || !args[2]->IsString(), "Wrong arguments");
+            V8CHECK(info.Length() != 3, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsInt32Array() || info[0]->IsNull() || info[0]->IsUndefined()) ||
+                !info[1]->IsInt32() || !info[2]->IsString(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
@@ -1023,8 +1023,8 @@ namespace NodeGLPK {
             int* plist = NULL;
             int ret = 0;
             GLP_CATCH(
-                if (args[0]->IsInt32Array()) {
-                    Local<Int32Array> list = Local<Int32Array>::Cast(args[0]);
+                if (info[0]->IsInt32Array()) {
+                    Local<Int32Array> list = Local<Int32Array>::Cast(info[0]);
                     count = list->Length();
                     if (count > 1) {
                         plist = new int[count];
@@ -1033,18 +1033,18 @@ namespace NodeGLPK {
                     }
                 }
                       
-                ret = glp_print_ranges(lp->handle, count, plist, args[1]->Int32Value(), V8TOCSTRING(args[2]));
+                ret = glp_print_ranges(lp->handle, count, plist, info[1]->Int32Value(), V8TOCSTRING(info[2]));
                       
             )
             if (plist) delete[] plist;
-            NanReturnValue(ret);
+            info.GetReturnValue().Set(ret);
         }
         
         
-        class PrintRangesWorker : public NanAsyncWorker {
+        class PrintRangesWorker : public Nan::AsyncWorker {
         public:
-            PrintRangesWorker(NanCallback *callback, Problem *lp, int len, int flags, char *file)
-            : NanAsyncWorker(callback), lp(lp), len(len), flags(flags), file(file){
+            PrintRangesWorker(Nan::Callback *callback, Problem *lp, int len, int flags, char *file)
+            : Nan::AsyncWorker(callback), lp(lp), len(len), flags(flags), file(file){
                 if (len > 0)
                     list = new int[len];
                 else
@@ -1055,12 +1055,12 @@ namespace NodeGLPK {
             }
             
             void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -1078,46 +1078,46 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(PrintRanges) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 4, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsInt32Array() || args[0]->IsNull() || args[0]->IsUndefined()) ||
-                !args[1]->IsInt32() || !args[2]->IsString() || !args[3]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 4, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsInt32Array() || info[0]->IsNull() || info[0]->IsUndefined()) ||
+                !info[1]->IsInt32() || !info[2]->IsString() || !info[3]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             size_t len = 0;
             Local<Int32Array> list;
-            if (args[0]->IsInt32Array()) {
-                list = Local<Int32Array>::Cast(args[0]);
+            if (info[0]->IsInt32Array()) {
+                list = Local<Int32Array>::Cast(info[0]);
                 len = list->Length();
             }
             
-            NanCallback *callback = new NanCallback(args[3].As<Function>());
-            PrintRangesWorker *worker = new PrintRangesWorker(callback, lp, len, args[1]->Int32Value(), V8TOCSTRING(args[2]));
+            Nan::Callback *callback = new Nan::Callback(info[3].As<Function>());
+            PrintRangesWorker *worker = new PrintRangesWorker(callback, lp, len, info[1]->Int32Value(), V8TOCSTRING(info[2]));
             if (len > 0) {
                 for (size_t i = 0; i < len; i++) worker->list[i] = list->Get(i)->Int32Value();
                 worker->len--;
             }
             
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         static NAN_METHOD(GetBfcp) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
             GLP_CATCH_RET(
                 glp_bfcp bfcp;
                 glp_get_bfcp(lp->handle, &bfcp);
-                Local<Object> ret = NanNew<Object>();
+                Local<Object> ret = Nan::New<Object>();
                 GLP_SET_FIELD_INT32(ret, "type", bfcp.type);
                 GLP_SET_FIELD_DOUBLE(ret, "pivTol", bfcp.piv_tol);
                 GLP_SET_FIELD_INT32(ret, "pivLim", bfcp.piv_lim);
@@ -1126,17 +1126,17 @@ namespace NodeGLPK {
                 GLP_SET_FIELD_INT32(ret, "nfsMax", bfcp.nfs_max);
                 GLP_SET_FIELD_INT32(ret, "nrsMax", bfcp.nrs_max);
                       
-                NanReturnValue(ret);
+                info.GetReturnValue().Set(ret);
             )
         }
         
         static NAN_METHOD(SetBfcp) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 1, "Wrong number of arguments");
-            V8CHECK(!(args[0]->IsObject() || args[0]->IsNull() || args[0]->IsUndefined()), "Wrong arguments");
+            V8CHECK(info.Length() != 1, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsObject() || info[0]->IsNull() || info[0]->IsUndefined()), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
@@ -1144,8 +1144,8 @@ namespace NodeGLPK {
                       glp_bfcp bfcp;
                       glp_get_bfcp(lp->handle, &bfcp);
                       
-                      if (args[0]->IsObject()){
-                          Local<Object> obj = args[0]->ToObject();
+                      if (info[0]->IsObject()){
+                          Local<Object> obj = info[0]->ToObject();
                           Local<Array> props = obj->GetPropertyNames();
                           for(uint32_t i = 0; i < props->Length(); i++){
                               Local<Value> key = props->Get(i);
@@ -1184,14 +1184,14 @@ namespace NodeGLPK {
             )
         }
         
-        class ScaleWorker : public NanAsyncWorker {
+        class ScaleWorker : public Nan::AsyncWorker {
         public:
-            ScaleWorker(NanCallback *callback, Problem *lp, int param)
-            : NanAsyncWorker(callback), lp(lp), param(param){
+            ScaleWorker(Nan::Callback *callback, Problem *lp, int param)
+            : Nan::AsyncWorker(callback), lp(lp), param(param){
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -1206,31 +1206,31 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Scale) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 2, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32() || !args[1]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32() || !info[1]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[1].As<Function>());
-            ScaleWorker *worker = new ScaleWorker(callback, lp, args[0]->Int32Value());
+            Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
+            ScaleWorker *worker = new ScaleWorker(callback, lp, info[0]->Int32Value());
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
 
-        class FactorizeWorker : public NanAsyncWorker {
+        class FactorizeWorker : public Nan::AsyncWorker {
         public:
-            FactorizeWorker(NanCallback *callback, Problem *lp)
-            : NanAsyncWorker(callback), lp(lp) {
+            FactorizeWorker(Nan::Callback *callback, Problem *lp)
+            : Nan::AsyncWorker(callback), lp(lp) {
             }
             void WorkComplete() {
                 lp->thread = false;
-                NanAsyncWorker::WorkComplete();
+                Nan::AsyncWorker::WorkComplete();
             }
             void Execute () {
                 try {
@@ -1240,8 +1240,8 @@ namespace NodeGLPK {
                 }
             }
             void HandleOKCallback() {
-                Local<Value> args[] = {NanNull(), NanNew<Int32>(ret)};
-                callback->Call(2, args);
+                Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};
+                callback->Call(2, info);
             }
         public:
             Problem *lp;
@@ -1249,20 +1249,20 @@ namespace NodeGLPK {
         };
         
         static NAN_METHOD(Factorize) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 1, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsFunction(), "Wrong arguments");
+            V8CHECK(info.Length() != 1, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsFunction(), "Wrong arguments");
             
-            Problem* lp = ObjectWrap::Unwrap<Problem>(args.Holder());
+            Problem* lp = Nan::ObjectWrap::Unwrap<Problem>(info.Holder());
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread, "an async operation is inprogress");
             
-            NanCallback *callback = new NanCallback(args[0].As<Function>());
+            Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
             FactorizeWorker *worker = new FactorizeWorker(callback, lp);
             lp->thread = true;
-            NanAsyncQueueWorker(worker);
-            NanReturnUndefined();
+            Nan::AsyncQueueWorker(worker);
+            return;
         }
         
         

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -9,60 +9,60 @@ namespace NodeGLPK {
 
     using namespace v8;
     
-    class Tree : public node::ObjectWrap {
+    class Tree : public Nan::ObjectWrap {
     public:
         static void Init(Handle<Object> exports){
             // Prepare constructor template
-            Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(New);
-            tpl->SetClassName(NanNew<String>("Tree"));
+            Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+            tpl->SetClassName(Nan::New<String>("Tree").ToLocalChecked());
             tpl->InstanceTemplate()->SetInternalFieldCount(1);
             
             // prototypes
-            NODE_SET_PROTOTYPE_METHOD(tpl, "reason", Reason);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "terminate", Terminate);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "treeSize", TreeSize);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "currNode", CurrNode);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "nextNode", NextNode);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "prevNode", PrevNode);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "upNode", UpNode);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "nodeLevel", NodeLevel);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "nodeBound", NodeBound);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "bestNode", BestNode);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "mipGap", MipGap);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "rowAttrib", RowAttrib);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "poolSize", PoolSize);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "delRow", DelRow);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "clearPool", ClearPool);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "canBranch", CanBranch);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "branchUpon", BranchUpon);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "selectNode", SelectNode);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "addRow", AddRow);
-            NODE_SET_PROTOTYPE_METHOD(tpl, "heurSol", HeurSol);
+            Nan::SetPrototypeMethod(tpl, "reason", Reason);
+            Nan::SetPrototypeMethod(tpl, "terminate", Terminate);
+            Nan::SetPrototypeMethod(tpl, "treeSize", TreeSize);
+            Nan::SetPrototypeMethod(tpl, "currNode", CurrNode);
+            Nan::SetPrototypeMethod(tpl, "nextNode", NextNode);
+            Nan::SetPrototypeMethod(tpl, "prevNode", PrevNode);
+            Nan::SetPrototypeMethod(tpl, "upNode", UpNode);
+            Nan::SetPrototypeMethod(tpl, "nodeLevel", NodeLevel);
+            Nan::SetPrototypeMethod(tpl, "nodeBound", NodeBound);
+            Nan::SetPrototypeMethod(tpl, "bestNode", BestNode);
+            Nan::SetPrototypeMethod(tpl, "mipGap", MipGap);
+            Nan::SetPrototypeMethod(tpl, "rowAttrib", RowAttrib);
+            Nan::SetPrototypeMethod(tpl, "poolSize", PoolSize);
+            Nan::SetPrototypeMethod(tpl, "delRow", DelRow);
+            Nan::SetPrototypeMethod(tpl, "clearPool", ClearPool);
+            Nan::SetPrototypeMethod(tpl, "canBranch", CanBranch);
+            Nan::SetPrototypeMethod(tpl, "branchUpon", BranchUpon);
+            Nan::SetPrototypeMethod(tpl, "selectNode", SelectNode);
+            Nan::SetPrototypeMethod(tpl, "addRow", AddRow);
+            Nan::SetPrototypeMethod(tpl, "heurSol", HeurSol);
             
-            NanAssignPersistent(constructor, tpl);
+            constructor.Reset(v8::Isolate::GetCurrent(), tpl);
         }
 
         static Local<Value> Instantiate(glp_tree* tree){
-            Local<Function> cons = NanNew<FunctionTemplate>(constructor)->GetFunction();
+            Local<Function> cons = Nan::New<FunctionTemplate>(constructor)->GetFunction();
             Local<Value> ret = cons->NewInstance();
-            Tree* host = ObjectWrap::Unwrap<Tree>(ret->ToObject());
+            Tree* host = Nan::ObjectWrap::Unwrap<Tree>(ret->ToObject());
             host->handle = tree;
             host->thread = false;
             return ret;
         }
     private:
-        explicit Tree(): node::ObjectWrap(){};
+        explicit Tree(): Nan::ObjectWrap(){};
         ~Tree(){};
         
         static NAN_METHOD(New) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(!args.IsConstructCall(), "Constructor Tree requires 'new'");
+            V8CHECK(!info.IsConstructCall(), "Constructor Tree requires 'new'");
             
             GLP_CATCH_RET(
-                      Tree* obj = new Tree();
-                      obj->Wrap(args.This());
-                      NanReturnValue(args.This());
+              Tree* obj = new Tree();
+              obj->Wrap(info.This());
+              info.GetReturnValue().Set(info.This());
             )
         }
         
@@ -71,20 +71,20 @@ namespace NodeGLPK {
         GLP_BIND_VOID(Tree, Terminate, glp_ios_terminate);
         
         static NAN_METHOD(TreeSize) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            Tree* host = ObjectWrap::Unwrap<Tree>(args.Holder());
+            Tree* host = Nan::ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread, "an async operation is inprogress");
             
             int a_cnt, n_cnt, t_cnt;
             GLP_CATCH_RET(glp_ios_tree_size(host->handle, &a_cnt, &n_cnt, &t_cnt);)
-            Local<Object> ret = NanNew<Object>();
+            Local<Object> ret = Nan::New<Object>();
             GLP_SET_FIELD_INT32(ret, "a", a_cnt);
             GLP_SET_FIELD_INT32(ret, "n", n_cnt);
             GLP_SET_FIELD_INT32(ret, "t", t_cnt);
             
-            NanReturnValue(ret);
+            info.GetReturnValue().Set(ret);
         }
         
         GLP_BIND_VALUE(Tree, CurrNode, glp_ios_curr_node);
@@ -104,41 +104,41 @@ namespace NodeGLPK {
         GLP_BIND_VALUE(Tree, MipGap, glp_ios_mip_gap);
         
         static NAN_METHOD(RowAttrib) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 1, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsInt32(), "Wrong arguments");
+            V8CHECK(info.Length() != 1, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsInt32(), "Wrong arguments");
             
-            Tree* host = ObjectWrap::Unwrap<Tree>(args.Holder());
+            Tree* host = Nan::ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread, "an async operation is inprogress");
             
             glp_attr attr;
-            GLP_CATCH_RET(glp_ios_row_attr(host->handle, args[0]->Int32Value(), &attr);)
+            GLP_CATCH_RET(glp_ios_row_attr(host->handle, info[0]->Int32Value(), &attr);)
             
-            Local<Object> ret = NanNew<Object>();
+            Local<Object> ret = Nan::New<Object>();
             GLP_SET_FIELD_INT32(ret, "level", attr.level);
             GLP_SET_FIELD_INT32(ret, "origin", attr.origin);
             GLP_SET_FIELD_INT32(ret, "klass", attr.klass);
             
-            NanReturnValue(ret);
+            info.GetReturnValue().Set(ret);
         }
         
         GLP_BIND_VALUE(Tree, PoolSize, glp_ios_pool_size);
         
         static NAN_METHOD(AddRow) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 7, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsString() || !args[1]->IsInt32() || !args[2]->IsInt32() || !args[3]->IsInt32Array()
-                    || !args[4]->IsFloat64Array() || !args[5]->IsInt32() || !args[6]->IsNumber(), "Wrong arguments");
+            V8CHECK(info.Length() != 7, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsString() || !info[1]->IsInt32() || !info[2]->IsInt32() || !info[3]->IsInt32Array()
+                    || !info[4]->IsFloat64Array() || !info[5]->IsInt32() || !info[6]->IsNumber(), "Wrong arguments");
             
-            Tree* tree = ObjectWrap::Unwrap<Tree>(args.Holder());
+            Tree* tree = Nan::ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread, "an async operation is inprogress");
             
-            Local<Int32Array> ind = Local<Int32Array>::Cast(args[3]);
-            Local<Float64Array> val = Local<Float64Array>::Cast(args[4]);
+            Local<Int32Array> ind = Local<Int32Array>::Cast(info[3]);
+            Local<Float64Array> val = Local<Float64Array>::Cast(info[4]);
             
             unsigned int count = ind->Length();
             V8CHECK((count < 1) || (count != val->Length()), "Invalid arrays length");
@@ -152,8 +152,8 @@ namespace NodeGLPK {
             }
             
             count--;
-            GLP_CATCH(NanReturnValue(glp_ios_add_row(tree->handle, V8TOCSTRING(args[0]), args[1]->Int32Value(),
-                args[2]->Int32Value(), count, pind, pval, args[5]->Int32Value(), args[6]->NumberValue()));)
+            GLP_CATCH(info.GetReturnValue().Set(glp_ios_add_row(tree->handle, V8TOCSTRING(info[0]), info[1]->Int32Value(),
+                info[2]->Int32Value(), count, pind, pval, info[5]->Int32Value(), info[6]->NumberValue()));)
             
             free(pind);
             free(pval);
@@ -170,23 +170,23 @@ namespace NodeGLPK {
         GLP_BIND_VOID_INT32(Tree, SelectNode, glp_ios_select_node);
         
         static NAN_METHOD(HeurSol) {
-            NanScope();
+            Nan::HandleScope scope;
             
-            V8CHECK(args.Length() != 1, "Wrong number of arguments");
-            V8CHECK(!args[0]->IsFloat64Array(), "Wrong arguments");
+            V8CHECK(info.Length() != 1, "Wrong number of arguments");
+            V8CHECK(!info[0]->IsFloat64Array(), "Wrong arguments");
         
-            Tree* tree = ObjectWrap::Unwrap<Tree>(args.Holder());
+            Tree* tree = Nan::ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread, "an async operation is inprogress");
             
-            Local<Float64Array> x = Local<Float64Array>::Cast(args[0]);
+            Local<Float64Array> x = Local<Float64Array>::Cast(info[0]);
             
             int count = (int)x->Length();
             GLP_CATCH_RET(V8CHECK(count != (glp_get_num_cols(glp_ios_get_prob(tree->handle)) + 1), "Invalid arrays length");)
             
             double* px = (double*)malloc(count * sizeof(double));
             for (int i = 0; i < count; i++) px[i] = x->NumberValue();
-            GLP_CATCH(NanReturnValue(glp_ios_heur_sol(tree->handle, px));)
+            GLP_CATCH(info.GetReturnValue().Set(glp_ios_heur_sol(tree->handle, px));)
             free(px);
         }
     public:


### PR DESCRIPTION
@hulbert

Compiles on node v4.2.2.

Build instructions:

```
$ nvm install v4.2.2
$ nvm use v4.2.2
$ npm install node-gyp
$ ./node_modules/.bin/node-gyp configure
$ ./node_modules/.bin/node-gyp build
```

Major steps used to convert to node v4:
- Updated to nan 2.1.0
- Used this script https://github.com/nodejs/nan/issues/376#issuecomment-120838432 to convert most of the codebase
- Most nan values were `MaybeLocal` instead of `Local` (which is kind of an optional -- see https://github.com/nodejs/nan/blob/master/doc/maybe_types.md#api_nan_maybe_local), force converted them to `Local` with `ToLocalChecked()` (unsafe).
- `args` was renamed to `info`
- Rest was just a matter of reading more nan doc
