### PR TITLE
Instrument term_hook as event emitter

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,19 +1,26 @@
 {
-  "targets": [
-    {
-      "target_name": "glpk",
-      "sources": [ "src/nodeglpk.cc", "src/problem.hpp", "src/tree.hpp"],
-      "cflags": [ "-fexceptions" ],
-      "cflags_cc": [ "-fexceptions" ],
-      "conditions": [
-            ['OS=="mac"', {
-                "xcode_settings": {
-                    "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
-                }
-            }]
-        ],
-      "dependencies": [ "src/glpk/glpk.gyp:libglpk" ],
-      "include_dirs": [ "<!(node -e \"require('nan')\")" ],
-    }
-  ]
+	"targets": [
+		{
+			"target_name": "glpk",
+			"sources": [ "src/nodeglpk.cc", "src/problem.hpp", "src/tree.hpp"],
+			"cflags": ["-std=c++11", "-Wall", "-Wextra", "-Wno-unused-parameter", "-fexceptions"],
+			"cflags_cc": ["-std=c++11", "-Wall", "-Wextra", "-Wno-unused-parameter", "-fexceptions"],
+			"defines": [
+				"HAVE_ENV"
+			],
+			"conditions": [
+				['OS=="mac"', {
+					"xcode_settings": {
+						"GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+						"CLANG_CXX_LIBRARY": "libc++",
+						"GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+						"MACOSX_DEPLOYMENT_TARGET": "10.10",
+						"OTHER_CPLUSPLUSFLAGS": ["-std=c++11", "-Wall", "-Wextra", "-Wno-unused-parameter", "-fexceptions"],
+					}
+				}]
+			],
+			"dependencies": [ "src/glpk/glpk.gyp:libglpk" ],
+			"include_dirs": [ "<!(node -e \"require('nan')\")", "<!(node -e 'require(\"cpp-eventemitter\")')" ],
+		}
+	]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     ],
   "dependencies": {
     "nan": "^2.1.0",
-    "bindings": "^1.2.1"
+    "bindings": "^1.2.1",
+    "cpp-eventemitter": "^0.0.1"
   },
   "scripts": {
     "configure": "node-gyp configure",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cpp-eventemitter": "^0.0.1"
   },
   "scripts": {
+    "test": "node-gyp configure --debug; node-gyp build --debug; mocha test/*-test.js",
     "configure": "node-gyp configure",
     "build": "node-gyp build"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "iojs": "*"
   },
   "devDependencies": {
-    "node-gyp": "^3.6.2"
+    "chai": "^4.0.2",
+    "mocha": "^3.4.2",
+    "node-gyp": "^3.6.2",
+    "temp": "^0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "nan": "^2.1.0",
     "bindings": "^1.2.1",
-    "cpp-eventemitter": "TakeScoop/cpp-eventemitter#jamie/review_feedback"
+    "cpp-eventemitter": "TakeScoop/cpp-eventemitter#c6c6927"
   },
   "scripts": {
     "test": "node-gyp configure --debug; node-gyp build --debug; mocha test/*-test.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "authors": [
     "Henri Gourvest <hgourvest@progdigy.com>"
   ],
-   "repository": {
+  "repository": {
     "type": "git",
     "url": "git://github.com/hgourvest/node-glpk.git"
   },
@@ -14,7 +14,7 @@
   "description": "Node.js native module for GLPK.",
   "keywords": [
     "glpk"
-    ],
+  ],
   "dependencies": {
     "nan": "^2.1.0",
     "bindings": "^1.2.1",
@@ -24,5 +24,11 @@
     "configure": "node-gyp configure",
     "build": "node-gyp build"
   },
-  "engines" : { "node" : ">=0.11.0", "iojs": "*" }
+  "engines": {
+    "node": ">=0.11.0",
+    "iojs": "*"
+  },
+  "devDependencies": {
+    "node-gyp": "^3.6.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "nan": "^2.1.0",
     "bindings": "^1.2.1",
-    "cpp-eventemitter": "^0.0.1"
+    "cpp-eventemitter": "TakeScoop/cpp-eventemitter#jamie\/review_feedback"
   },
   "scripts": {
     "test": "node-gyp configure --debug; node-gyp build --debug; mocha test/*-test.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "nan": "^2.1.0",
     "bindings": "^1.2.1",
-    "cpp-eventemitter": "TakeScoop/cpp-eventemitter#jamie\/review_feedback"
+    "cpp-eventemitter": "TakeScoop/cpp-eventemitter#jamie/review_feedback"
   },
   "scripts": {
     "test": "node-gyp configure --debug; node-gyp build --debug; mocha test/*-test.js",
@@ -30,7 +30,7 @@
     "iojs": "*"
   },
   "devDependencies": {
-    "chai": "^4.0.2",
+    "code": "^4.1.0",
     "mocha": "^3.4.2",
     "node-gyp": "^3.6.2",
     "temp": "^0.8.3"

--- a/src/common.h
+++ b/src/common.h
@@ -49,8 +49,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, V8TOCSTRING(info[0]));)\
 }
 
@@ -58,8 +59,9 @@ static NAN_METHOD(NAME) {\
 static NAN_METHOD(NAME) {\
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(const char* name = API(host->handle);\
     if (name)\
         info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
@@ -74,8 +76,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value());)\
 }
 
@@ -83,8 +86,9 @@ static NAN_METHOD(NAME) {\
 static NAN_METHOD(NAME) {\
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle));)\
 }
 
@@ -95,8 +99,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1]));)\
 }
 
@@ -107,8 +112,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(const char* name = API(host->handle, info[0]->Int32Value());\
     if (name)\
         info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
@@ -124,8 +130,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value(),\
                      info[2]->NumberValue(), info[3]->NumberValue());)\
 }
@@ -137,8 +144,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->NumberValue());)\
 }
 
@@ -149,8 +157,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value()));)\
 }
 
@@ -168,7 +177,7 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
     int* pja = (int*)malloc(ja->Length() * sizeof(int));\
     double* par = (double*)malloc(ar->Length() * sizeof(double));\
@@ -176,6 +185,7 @@ static NAN_METHOD(NAME) {\
     for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();\
     for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), count, pja, par);)\
     \
     free(pja);\
@@ -189,8 +199,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     try{\
         int row = info[0]->Int32Value();\
         int count = API(host->handle, row, NULL, NULL);\
@@ -223,8 +234,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle);)\
 }
 
@@ -241,9 +253,10 @@ static NAN_METHOD(NAME) {\
     for (int i = 0; i < count; i++) idx[i] = num->Get(i)->Int32Value();\
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
     count--;\
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, count, idx);)\
     free(idx);\
 }
@@ -255,8 +268,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0])));)\
 }
 
@@ -267,8 +281,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value());)\
 }
 
@@ -279,8 +294,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1])));)\
 }
 
@@ -291,8 +307,9 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* host = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!host->handle, "object deleted");\
-    V8CHECK(host->thread, "an async operation is inprogress")\
+    V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0]), info[1]->Int32Value()));)\
 }
 
@@ -302,6 +319,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!obj->handle, "object already deleted");\
     V8CHECK(obj->thread, "an async operation is inprogress")\
     \
+    TermHookGuard hookguard{&obj->info_}; \
     GLP_CATCH_RET(API(obj->handle);)\
     obj->handle = NULL;\
 }
@@ -314,29 +332,31 @@ OBJ->Set(Nan::New<String>(KEY).ToLocalChecked(), Nan::New<Number>(VALUE));
 
 
 #define GLP_ASYNC_INT32_STR(CLASS, NAME, API)\
-class NAME##Worker : public Nan::AsyncWorker {\
+class NAME##Worker : public ReentrantCWorker {\
 public:\
 NAME##Worker(Nan::Callback *callback, CLASS *lp, std::string file)\
-: Nan::AsyncWorker(callback), lp(lp), file(file){\
+: ReentrantCWorker(callback, lp->emitter_), lp(lp), file(file){\
     \
 }\
-\
-void Execute () {\
+virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override { \
+    HookInfo info {nullptr, sender, fn}; \
+    TermHookGuard hookguard{&info}; \
     try {\
         ret = API(lp->handle, file.c_str());\
     } catch (std::string s) {\
         Nan::ThrowError(s.c_str());\
     }\
 }\
-void WorkComplete() {\
+virtual void WorkComplete() override {\
     lp->thread = false;\
-    Nan::AsyncWorker::WorkComplete();\
+    ReentrantCWorker::WorkComplete();\
 }\
-virtual void HandleOKCallback() {\
+virtual void HandleOKCallback() override {\
     Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};\
     callback->Call(2, info);\
 }\
 \
+private:\
 public:\
     int ret;\
     CLASS *lp;\
@@ -349,7 +369,7 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* lp = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!lp->handle, "object deleted");\
-    V8CHECK(lp->thread, "an async operation is inprogress")\
+    V8CHECK(lp->thread.load(), "an async operation is inprogress")\
     \
     Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());\
     NAME##Worker *worker = new NAME##Worker(callback, lp, V8TOCSTRING(info[0]));\
@@ -358,17 +378,19 @@ static NAN_METHOD(NAME) {\
 }\
 
 #define GLP_ASYNC_INT32_INT32_STR(CLASS, NAME, API)\
-class NAME##Worker : public Nan::AsyncWorker {\
+class NAME##Worker : public ReentrantCWorker {\
 public:\
     NAME##Worker(Nan::Callback *callback, CLASS *lp, int flags, std::string file)\
-    : Nan::AsyncWorker(callback), flags(flags), lp(lp), file(file){\
+    : ReentrantCWorker(callback, lp->emitter_), flags(flags), lp(lp), file(file){\
         \
     }\
-    void WorkComplete() {\
+    virtual void WorkComplete() override {\
         lp->thread = false;\
-        Nan::AsyncWorker::WorkComplete();\
+        ReentrantCWorker::WorkComplete();\
     }\
-    void Execute () {\
+    virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override { \
+        HookInfo info {nullptr, sender, fn}; \
+        TermHookGuard hookguard{&info}; \
         try {\
             ret = API(lp->handle, flags, file.c_str());\
         } catch (std::string s) {\
@@ -376,11 +398,12 @@ public:\
         }\
     }\
     \
-    virtual void HandleOKCallback() {\
+    virtual void HandleOKCallback() override {\
         Local<Value> info[] = {Nan::Null(), Nan::New<Int32>(ret)};\
         callback->Call(2, info);\
     }\
     \
+private:\
 public:\
     int ret, flags;\
     CLASS *lp;\
@@ -402,22 +425,25 @@ static NAN_METHOD(NAME) {\
 }\
 
 #define GLP_ASYNC_VOID(CLASS, NAME, API)\
-class NAME##Worker : public Nan::AsyncWorker {\
+class NAME##Worker : public ReentrantCWorker {\
 public:\
     NAME##Worker(Nan::Callback *callback, CLASS *lp)\
-    : Nan::AsyncWorker(callback), lp(lp) {\
+    : ReentrantCWorker(callback, lp->emitter_), lp(lp) {\
     }\
-    void WorkComplete() {\
+    virtual void WorkComplete() override {\
         lp->thread = false;\
-        Nan::AsyncWorker::WorkComplete();\
+        ReentrantCWorker::WorkComplete();\
     }\
-    void Execute () {\
+    virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override { \
+        HookInfo info {nullptr, sender, fn}; \
+        TermHookGuard hookguard{&info}; \
         try {\
             API(lp->handle);\
         } catch (std::string s) {\
             Nan::ThrowError(s.c_str());\
         }\
     }\
+private:\
 public:\
     CLASS *lp;\
 };\
@@ -428,7 +454,7 @@ static NAN_METHOD(NAME) {\
     \
     CLASS* lp = ObjectWrap::Unwrap<CLASS>(info.Holder());\
     V8CHECK(!lp->handle, "object deleted");\
-    V8CHECK(lp->thread, "an async operation is inprogress")\
+    V8CHECK(lp->thread.load(), "an async operation is inprogress")\
     \
     Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());\
     NAME##Worker *worker = new NAME##Worker(callback, lp);\

--- a/src/common.h
+++ b/src/common.h
@@ -51,7 +51,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, V8TOCSTRING(info[0]));)\
 }
 
@@ -61,7 +61,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(const char* name = API(host->handle);\
     if (name)\
         info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
@@ -78,7 +78,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value());)\
 }
 
@@ -88,7 +88,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle));)\
 }
 
@@ -101,7 +101,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1]));)\
 }
 
@@ -114,7 +114,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(const char* name = API(host->handle, info[0]->Int32Value());\
     if (name)\
         info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
@@ -132,7 +132,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value(),\
                      info[2]->NumberValue(), info[3]->NumberValue());)\
 }
@@ -146,7 +146,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->NumberValue());)\
 }
 
@@ -159,7 +159,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value()));)\
 }
 
@@ -185,7 +185,7 @@ static NAN_METHOD(NAME) {\
     for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();\
     for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), count, pja, par);)\
     \
     free(pja);\
@@ -201,7 +201,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     try{\
         int row = info[0]->Int32Value();\
         int count = API(host->handle, row, NULL, NULL);\
@@ -236,7 +236,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle);)\
 }
 
@@ -256,7 +256,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
     count--;\
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, count, idx);)\
     free(idx);\
 }
@@ -270,7 +270,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0])));)\
 }
 
@@ -283,7 +283,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value());)\
 }
 
@@ -296,7 +296,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1])));)\
 }
 
@@ -309,7 +309,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&host->info_}; \
+    TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0]), info[1]->Int32Value()));)\
 }
 
@@ -319,7 +319,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!obj->handle, "object already deleted");\
     V8CHECK(obj->thread, "an async operation is inprogress")\
     \
-    TermHookGuard hookguard{&obj->info_}; \
+    TermHookGuard hookguard{obj->info_}; \
     GLP_CATCH_RET(API(obj->handle);)\
     obj->handle = NULL;\
 }

--- a/src/common.h
+++ b/src/common.h
@@ -340,7 +340,7 @@ NAME##Worker(Nan::Callback *callback, CLASS *lp, std::string file)\
 }\
 virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override { \
     HookInfo info {nullptr, sender, fn}; \
-    TermHookGuard hookguard{&info}; \
+    TermHookThreadGuard hookguard{&info}; \
     try {\
         ret = API(lp->handle, file.c_str());\
     } catch (std::string s) {\
@@ -390,7 +390,7 @@ public:\
     }\
     virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override { \
         HookInfo info {nullptr, sender, fn}; \
-        TermHookGuard hookguard{&info}; \
+        TermHookThreadGuard hookguard{&info}; \
         try {\
             ret = API(lp->handle, flags, file.c_str());\
         } catch (std::string s) {\
@@ -436,7 +436,7 @@ public:\
     }\
     virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override { \
         HookInfo info {nullptr, sender, fn}; \
-        TermHookGuard hookguard{&info}; \
+        TermHookThreadGuard hookguard{&info}; \
         try {\
             API(lp->handle);\
         } catch (std::string s) {\

--- a/src/glpk/env/glpenv.h
+++ b/src/glpk/env/glpenv.h
@@ -31,7 +31,9 @@ typedef struct ENV ENV;
 typedef struct MBD MBD;
 #endif
 
+#ifndef SIZE_T_MAX
 #define SIZE_T_MAX (~(size_t)0)
+#endif
 /* largest value of size_t type */
 
 

--- a/src/glpk/env/stdout.c
+++ b/src/glpk/env/stdout.c
@@ -53,8 +53,10 @@ void glp_puts(const char *s)
             goto skip;
       }
       /* write the string on the terminal */
-      fputs(s, stdout);
-      fflush(stdout);
+      /* term_hook does this; don't write twice.
+       * fputs(s, stdout);
+       * fflush(stdout);
+      */
       /* write the string on the tee file, if required */
       if (env->tee_file != NULL)
       {  fputs(s, env->tee_file);

--- a/src/glpk/env/stdout.c
+++ b/src/glpk/env/stdout.c
@@ -27,7 +27,7 @@
 
 #ifndef HAVE_ENV
 static void (*_term_hook_)(const char *) = NULL;
-#endif;
+#endif
 
 /***********************************************************************
 *  NAME
@@ -143,6 +143,7 @@ void glp_vprintf(const char *fmt, va_list arg)
       assert(strlen(env->term_buf) < TBUF_SIZE);
       /* write the formatted output on the terminal */
       glp_puts(env->term_buf);
+skip: return;
 #else
     char term_buf[TBUF_SIZE];
     // if terminal output is disabled, do nothing

--- a/src/glpk/env/tls.c
+++ b/src/glpk/env/tls.c
@@ -23,9 +23,26 @@
 
 #include "glpenv.h"
 
-static void *tls = NULL;
-/* NOTE: in a re-entrant version of the package this variable should be
- * placed in the Thread Local Storage (TLS) */
+#ifndef thread_local
+# if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#  define thread_local _Thread_local
+# elif defined _WIN32 && ( \
+       defined _MSC_VER || \
+       defined __ICL || \
+       defined __DMC__ || \
+       defined __BORLANDC__ )
+#  define thread_local __declspec(thread)
+/* note that ICC (linux) and Clang are covered by __GNUC__ */
+# elif defined __GNUC__ || \
+       defined __SUNPRO_C || \
+       defined __xlC__
+#  define thread_local __thread
+# else
+#  error "Cannot define thread_local"
+# endif
+#endif
+
+thread_local static void *tls = NULL;
 
 /***********************************************************************
 *  NAME

--- a/src/glpk/env/tls.c
+++ b/src/glpk/env/tls.c
@@ -42,7 +42,7 @@
 # endif
 #endif
 
-thread_local static void *tls = NULL;
+static thread_local void *tls = NULL;
 
 /***********************************************************************
 *  NAME

--- a/src/glpk/glpapi06.c
+++ b/src/glpk/glpapi06.c
@@ -22,7 +22,7 @@
 *  along with GLPK. If not, see <http://www.gnu.org/licenses/>.
 ***********************************************************************/
 
-#include "glpenv.h"
+#include "env/glpenv.h"
 #include "glpios.h"
 #include "glpnpp.h"
 #if 0 /* 07/XI-2015 */

--- a/src/glpk/glpk.gyp
+++ b/src/glpk/glpk.gyp
@@ -4,7 +4,8 @@
       "target_name": "libglpk",
       "type": "static_library",
 	  "defines": [
-		"HAVE_GETTIMEOFDAY"
+		"HAVE_GETTIMEOFDAY",
+		"HAVE_ENV"
       ],
       "conditions": [
 		['OS=="linux"', {
@@ -25,7 +26,8 @@
 		"./misc/",
 		"./proxy/",
 		"./simplex/",
-		"./zlib/"
+		"./zlib/",
+		"<!(node -e 'require(\"cpp-eventemitter\")')"
       ],
       "sources": [
  		"avl.c",

--- a/src/glpk/glpk.gyp
+++ b/src/glpk/glpk.gyp
@@ -5,7 +5,9 @@
       "type": "static_library",
 	  "defines": [
 		"HAVE_GETTIMEOFDAY",
-		"HAVE_ENV"
+		"HAVE_ENV",
+		"HAVE_ATOMIC",
+		"GLOBAL_MEM_STATS",
       ],
       "conditions": [
 		['OS=="linux"', {

--- a/src/glpk/glpk.h
+++ b/src/glpk/glpk.h
@@ -25,8 +25,11 @@
 #ifndef GLPK_H
 #define GLPK_H
 
+
 #include <stdarg.h>
 #include <stddef.h>
+
+#include <cemitter.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -25,6 +25,7 @@ namespace NodeGLPK {
             tpl->InstanceTemplate()->SetInternalFieldCount(1);
  
             // prototypes
+            Nan::SetPrototypeMethod(tpl, "on", On);
             Nan::SetPrototypeMethod(tpl, "readModelSync", ReadModelSync);
             Nan::SetPrototypeMethod(tpl, "readModel", ReadModel);
             Nan::SetPrototypeMethod(tpl, "readDataSync", ReadDataSync);
@@ -61,7 +62,19 @@ namespace NodeGLPK {
                       info.GetReturnValue().Set(info.This());
             );
         }
-        
+
+        static NAN_METHOD(On) {
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsString() || !info[1]->IsFunction()), "Wrong arguments");
+
+            Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(info.Holder());
+            V8CHECK(!mp->handle, "object deleted");
+
+            auto s = std::string(*v8::String::Utf8Value(info[0]->ToString()));
+            Nan::Callback* callback = new Nan::Callback(info[1].As<Function>());
+
+            mp->emitter_->on(s, callback);
+        }
         
         class ReadModelWorker : public ReentrantCWorker {
         public:

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -89,7 +89,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&info};
+                TermHookThreadGuard hookguard{&info};
                 try {
                     ret = glp_mpl_read_model(mp->handle, file.c_str(), parm);
                 } catch (std::string s){
@@ -135,7 +135,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&info};
+                TermHookThreadGuard hookguard{&info};
                 try {
                     ret = glp_mpl_read_data(mp->handle, file.c_str());
                 } catch (std::string s){
@@ -181,7 +181,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&info};
+                TermHookThreadGuard hookguard{&info};
                 try {
                     if (file.length() > 0)
                         ret = glp_mpl_generate(mp->handle, file.c_str());
@@ -250,7 +250,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&info};
+                TermHookThreadGuard hookguard{&info};
                 try {
                     glp_mpl_build_prob(mp->handle, lp->handle);
                 } catch (std::string s){
@@ -311,7 +311,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&info};
+                TermHookThreadGuard hookguard{&info};
                 try {
                     ret = glp_mpl_postsolve(mp->handle, lp->handle, parm);
                 } catch (std::string s){

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <iostream>
 
 #include <eventemitter.hpp>
 #include <node.h>

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -57,8 +57,6 @@ extern "C" {
 
     
     void Init(Handle<Object> exports) {
-        TermHookManager::ThreadInitDefaultHooks(nullptr);
-
         exports->Set(Nan::New<String>("termOutput").ToLocalChecked(), Nan::New<FunctionTemplate>(TermOutput)->GetFunction());
         
         GLP_DEFINE_CONSTANT(exports, GLP_MAJOR_VERSION, MAJOR_VERSION);

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -14,8 +14,8 @@ using namespace v8;
 using namespace NodeGLPK;
 
 namespace NodeGLPK {
-std::vector<term_hook_fn> TermHookManager::term_hooks_;
-thread_local HookInfo* TermHookManager::info_;
+std::vector<term_hook_fn> TermHookManager::term_hooks_{stdoutTermHook, eventTermHook}; 
+thread_local HookInfo* TermHookManager::info_{nullptr};
 NodeEvent::uv_rwlock TermHookManager::lock_;
 
 static std::atomic<bool> term_output{false};

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -12,7 +12,11 @@
 using namespace v8;
 using namespace NodeGLPK;
 
+namespace NodeGLPK {
 std::vector<term_hook_fn> TermHookManager::term_hooks_;
+thread_local HookInfo* TermHookManager::info_;
+NodeEvent::uv_rwlock TermHookManager::lock_;
+
 static std::atomic<bool> term_output{false};
 
 int stdoutTermHook(void*, const char *s) {
@@ -39,13 +43,15 @@ void _ErrorHook(void *s){
     throw std::string(static_cast<const char *>(s));
 }
 
+} // namespace NodeGLPK
+
 extern "C" {
     
     NAN_METHOD(TermOutput) {
         V8CHECK(info.Length() != 1, "Wrong number of arguments");
         V8CHECK(!info[0]->IsBoolean(), "Wrong arguments");
         
-        term_output = info[0]->BooleanValue();
+        NodeGLPK::term_output = info[0]->BooleanValue();
     }
 
     

--- a/src/nodeglpk.cc
+++ b/src/nodeglpk.cc
@@ -15,7 +15,7 @@ using namespace NodeGLPK;
 
 namespace NodeGLPK {
 std::vector<term_hook_fn> TermHookManager::term_hooks_{stdoutTermHook, eventTermHook}; 
-thread_local HookInfo* TermHookManager::info_{nullptr};
+thread_local std::shared_ptr<HookInfo> TermHookManager::info_{nullptr};
 NodeEvent::uv_rwlock TermHookManager::lock_;
 
 static std::atomic<bool> term_output{false};

--- a/src/nodeglpk.hpp
+++ b/src/nodeglpk.hpp
@@ -122,10 +122,26 @@ class TermHookGuard {
             oldinfo_ = TermHookManager::SetInfo(info);
         }
     }
-    ~TermHookGuard() noexcept { TermHookManager::SetInfo(oldinfo_); glp_free_env(); }
+    ~TermHookGuard() noexcept { TermHookManager::SetInfo(oldinfo_); }
 
  private:
     HookInfo* oldinfo_;
+};
+
+/// TermHookThreadGuard is similar to TermHookGuard but instead of restoring the prior info, deletes the environment of
+/// the thread. This guard is suitable for the worker-thread method, where cleanup should happen when the thread
+/// completes.
+class TermHookThreadGuard {
+ public:
+    explicit TermHookThreadGuard(HookInfo* info) {
+        // Ensure this thread's env is setup and has our hooks
+        TermHookManager::ThreadInitDefaultHooks(nullptr);  
+        if (info && TermHookManager::Current() != info) {
+            TermHookManager::SetInfo(info);
+        }
+    }
+
+    ~TermHookThreadGuard() noexcept { glp_free_env(); }
 };
 
 }  // namespace NodeGLPK

--- a/src/nodeglpk.hpp
+++ b/src/nodeglpk.hpp
@@ -100,6 +100,12 @@ class TermHookManager {
     /// @returns the current info
     static HookInfo* Current() { return info_; }
 
+    /// free the environment of the current thread
+    static void ClearEnv() {
+        glp_free_env();
+        info_ = nullptr;
+    }
+
  private:
     static std::vector<term_hook_fn> term_hooks_;
     static NodeEvent::uv_rwlock lock_;
@@ -137,7 +143,7 @@ class TermHookThreadGuard {
         }
     }
 
-    ~TermHookThreadGuard() noexcept { glp_free_env(); }
+    ~TermHookThreadGuard() noexcept { TermHookManager::ClearEnv(); }
 };
 
 /// EventEmitterDecorator decorates a Nan::AsyncWorker so that the Execute() method is wrapped with a TermHookThreadGuard

--- a/src/nodeglpk.hpp
+++ b/src/nodeglpk.hpp
@@ -1,0 +1,132 @@
+#pragma once
+#ifndef _NODE_GLPK_NODEGLPK_H
+#define _NODE_GLPK_NODEGLPK_H
+
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <eventemitter.hpp>
+
+#include "glpk/glpk.h"
+
+namespace NodeGLPK {
+
+typedef int (*term_hook_fn)(void* info, const char* s);
+typedef NodeEvent::AsyncEventEmittingReentrantCWorker<128> ReentrantCWorker;
+
+/// The state information passed to all term_hooks. 
+struct HookInfo {
+    /// An emitter. Will be used if not-null, ignoring anything else.
+    std::shared_ptr<NodeEvent::EventEmitter> emitter;
+
+    /// The sender. both sender and fn must be set together. Only used if emitter is nullptr
+    const ReentrantCWorker::ExecutionProgressSender* sender;
+
+    /// The function to invoke (with sender as first argument). Only used if emitter is nullptr
+    eventemitter_fn_r fn;
+};
+
+int stdoutTermHook(void*, const char* s);
+int eventTermHook(void* info, const char* s);
+void _ErrorHook(void* s);
+
+/// TermHookManager provides static methods for managing TermHooks, and hook registration
+class TermHookManager {
+ public:
+    /// The callback registered with glp_term_hook. Runs through all the registered hooks and calls them in order
+    ///
+    /// @param[in] info - The info from the thread-local env
+    /// @param[in] s - the string being logged to term_hook
+    ///
+    /// @returns an integer; if any hook returns non-zero, will return that; 0 otherwise.
+    static int NodeHookCallback(void* info, const char* s) {
+        NodeEvent::shared_lock<NodeEvent::uv_rwlock> guard{lock_};
+        int ret = 0;
+        for (auto hook : term_hooks_) {
+            int r = hook(info, s);
+            if (r) {
+                ret = r;
+            }
+        }
+        return ret;
+    }
+
+    /// An Idempotent function for ensuring that the thread-local env is setup
+    /// Pass in info to set it for the thread (ignoring any prior values)
+    ///
+    /// @param[in] info - A hook info that will be valid for the life of the thread or until set to nullptr
+    static void ThreadInitDefaultHooks(HookInfo* info) {
+        glp_error_hook(_ErrorHook, info);
+        if (info) {
+            TermHookManager::SetInfo(info);
+        }
+        TermHookManager::AddHook(stdoutTermHook);
+        TermHookManager::AddHook(eventTermHook);
+    }
+
+    /// Add a hook to the list of hooks that will be run. Duplicate hooks will be ignored (must be a C compatible
+    /// function (ugly style function pointer) that can have it's address taken)
+    ///
+    /// @param[in] hook - The hook to add
+    static void AddHook(term_hook_fn hook) {
+        std::unique_lock<NodeEvent::uv_rwlock> guard{lock_};
+        for (auto existingHook : term_hooks_) {
+            // Skip duplicates
+            if (hook == existingHook) {
+                return;
+            }
+        }
+        term_hooks_.push_back(hook);
+    }
+
+    /// Clear all hooks registered with the TermHookManager
+    static void ClearHooks() {
+        std::unique_lock<NodeEvent::uv_rwlock> guard{lock_};
+        term_hooks_.clear();
+    }
+
+    /// Set the info for the current thread.
+    ///
+    /// @param[in] info - The info to set for this thread
+    ///
+    /// @returns the prior info, use this to restore the prior info back when you're done
+    static HookInfo* SetInfo(HookInfo* info) {
+        auto oldInfo = info_;
+        info_ = info;
+        glp_term_hook(NodeHookCallback, static_cast<void*>(info_));
+        return oldInfo;
+    }
+
+    /// @returns the current info
+    static HookInfo* Current() { return info_; }
+
+ private:
+    static std::vector<term_hook_fn> term_hooks_;
+    static NodeEvent::uv_rwlock lock_;
+    static thread_local HookInfo* info_;
+};
+
+/// TermHookGuard is an RAII container for HookInfo management. Ensures the prior info is restored regardless of how you
+/// exit a block. Declare the guard in the same scope (or nested scope) of wherever you allocate the NodeInfo you are
+/// setting to ensure you never have a dangling pointer
+///
+/// NOTE: This container does *NOT* free an info object for you; use stack-allocated info's; or wrap them in smart
+/// pointers.
+class TermHookGuard {
+ public:
+    explicit TermHookGuard(HookInfo* info) : oldinfo_(nullptr) {
+        // Ensure this thread's env is setup and has our hooks
+        TermHookManager::ThreadInitDefaultHooks(nullptr);  
+        if (info && TermHookManager::Current() != info) {
+            oldinfo_ = TermHookManager::SetInfo(info);
+        }
+    }
+    ~TermHookGuard() noexcept { TermHookManager::SetInfo(oldinfo_); }
+
+ private:
+    HookInfo* oldinfo_;
+};
+
+}  // namespace NodeGLPK
+#endif

--- a/src/nodeglpk.hpp
+++ b/src/nodeglpk.hpp
@@ -122,7 +122,7 @@ class TermHookGuard {
             oldinfo_ = TermHookManager::SetInfo(info);
         }
     }
-    ~TermHookGuard() noexcept { TermHookManager::SetInfo(oldinfo_); }
+    ~TermHookGuard() noexcept { TermHookManager::SetInfo(oldinfo_); glp_free_env(); }
 
  private:
     HookInfo* oldinfo_;

--- a/src/nodeglpk.hpp
+++ b/src/nodeglpk.hpp
@@ -53,17 +53,6 @@ class TermHookManager {
         return ret;
     }
 
-    /// An Idempotent function for ensuring that the thread-local env is setup
-    /// Pass in info to set it for the thread (ignoring any prior values)
-    ///
-    /// @param[in] info - A hook info that will be valid for the life of the thread or until set to nullptr
-    static void ThreadInitDefaultHooks(HookInfo* info) {
-        glp_error_hook(_ErrorHook, info);
-        if (info) {
-            TermHookManager::SetInfo(info);
-        }
-    }
-
     /// Add a hook to the list of hooks that will be run. Duplicate hooks will be ignored (must be a C compatible
     /// function (ugly style function pointer) that can have it's address taken)
     ///
@@ -93,6 +82,7 @@ class TermHookManager {
     static HookInfo* SetInfo(HookInfo* info) {
         auto oldInfo = info_;
         info_ = info;
+        glp_error_hook(_ErrorHook, static_cast<void*>(info));
         glp_term_hook(NodeHookCallback, static_cast<void*>(info_));
         return oldInfo;
     }
@@ -139,7 +129,7 @@ class TermHookThreadGuard {
     explicit TermHookThreadGuard(HookInfo* info) {
         // Ensure this thread's env is setup and has our hooks
         if(info && TermHookManager::Current() != info) { 
-            TermHookManager::ThreadInitDefaultHooks(info);  
+            TermHookManager::SetInfo(info);  
         }
     }
 

--- a/src/nodeglpk.hpp
+++ b/src/nodeglpk.hpp
@@ -10,10 +10,10 @@
 
 #include "glpk/glpk.h"
 
-namespace NodeGLPK {
 
+namespace NodeGLPK {
 typedef int (*term_hook_fn)(void* info, const char* s);
-typedef NodeEvent::AsyncEventEmittingReentrantCWorker<128> ReentrantCWorker;
+typedef NodeEvent::AsyncEventEmittingReentrantCWorker<32> ReentrantCWorker;
 
 /// The state information passed to all term_hooks. 
 struct HookInfo {

--- a/src/nodeglpk.hpp
+++ b/src/nodeglpk.hpp
@@ -62,8 +62,6 @@ class TermHookManager {
         if (info) {
             TermHookManager::SetInfo(info);
         }
-        TermHookManager::AddHook(stdoutTermHook);
-        TermHookManager::AddHook(eventTermHook);
     }
 
     /// Add a hook to the list of hooks that will be run. Duplicate hooks will be ignored (must be a C compatible
@@ -117,8 +115,6 @@ class TermHookManager {
 class TermHookGuard {
  public:
     explicit TermHookGuard(HookInfo* info) : oldinfo_(nullptr) {
-        // Ensure this thread's env is setup and has our hooks
-        TermHookManager::ThreadInitDefaultHooks(nullptr);  
         if (info && TermHookManager::Current() != info) {
             oldinfo_ = TermHookManager::SetInfo(info);
         }
@@ -136,9 +132,8 @@ class TermHookThreadGuard {
  public:
     explicit TermHookThreadGuard(HookInfo* info) {
         // Ensure this thread's env is setup and has our hooks
-        TermHookManager::ThreadInitDefaultHooks(nullptr);  
-        if (info && TermHookManager::Current() != info) {
-            TermHookManager::SetInfo(info);
+        if(info && TermHookManager::Current() != info) { 
+            TermHookManager::ThreadInitDefaultHooks(info);  
         }
     }
 

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -839,8 +839,10 @@ namespace NodeGLPK {
                 try {
                     glp_intopt_start(lp->handle, &ctx);
                     while(!ctx.done) {
-                        parm.cb_func(ctx.tree, parm.cb_info);
                         glp_intopt_run(&ctx);
+                        if(!ctx.done) {
+                            parm.cb_func(ctx.tree, parm.cb_info);
+                        }
                     }
                     glp_intopt_stop(lp->handle, &ctx);
                 } catch (std::string s){

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -29,6 +29,7 @@ namespace NodeGLPK {
             tpl->InstanceTemplate()->SetInternalFieldCount(1);
             
             // Prototype
+            Nan::SetPrototypeMethod(tpl, "on", On);
             Nan::SetPrototypeMethod(tpl, "setProbName", SetProbName);
             Nan::SetPrototypeMethod(tpl, "getProbName", GetProbName);
             Nan::SetPrototypeMethod(tpl, "setObjDir", SetObjDir);
@@ -239,7 +240,19 @@ namespace NodeGLPK {
                       obj->Wrap(info.This());
                       info.GetReturnValue().Set(info.This());
             );
+        }
 
+        static NAN_METHOD(On) {
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsString() || !info[1]->IsFunction()), "Wrong arguments");
+
+            Problem* lp = ObjectWrap::Unwrap<Problem>(info.Holder());
+            V8CHECK(!lp->handle, "object deleted");
+
+            auto s = std::string(*v8::String::Utf8Value(info[0]->ToString()));
+            Nan::Callback* callback = new Nan::Callback(info[1].As<Function>());
+
+            lp->emitter_->on(s, callback);
         }
 
         static NAN_METHOD(LoadMatrix) {

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -834,9 +834,8 @@ namespace NodeGLPK {
                ctx.parm = &parm;
 
 
-               auto async = new uv_async_t;
-               uv_async_init(uv_default_loop(), async, IntoptWorker::parmCallbackAsyncRun);
-               parm_cb_async_ = std::unique_ptr<uv_async_t>(async);
+               parm_cb_async_ = std::unique_ptr<uv_async_t>(new uv_async_t);
+               uv_async_init(uv_default_loop(), parm_cb_async_.get(), IntoptWorker::parmCallbackAsyncRun);
                parm_cb_async_->data = this;
             }
             

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -839,10 +839,8 @@ namespace NodeGLPK {
                 try {
                     glp_intopt_start(lp->handle, &ctx);
                     while(!ctx.done) {
+                        parm.cb_func(ctx.tree, parm.cb_info);
                         glp_intopt_run(&ctx);
-                        if(!ctx.done) {
-                            parm.cb_func(ctx.tree, parm.cb_info);
-                        }
                     }
                     glp_intopt_stop(lp->handle, &ctx);
                 } catch (std::string s){

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -321,7 +321,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&info};
+                TermHookThreadGuard hookguard{&info};
                 try {
                     glp_simplex(lp->handle, &smcp);
                 } catch (std::string s){
@@ -386,7 +386,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     glp_exact(lp->handle, &smcp);
                 } catch (std::string s){
@@ -473,7 +473,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     glp_interior(lp->handle, &iptcp);
                 } catch (std::string s){
@@ -573,7 +573,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     ret = glp_read_mps(lp->handle, fmt, &mpscp, file.c_str());
                 } catch (std::string s){
@@ -651,7 +651,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     ret = glp_write_mps(lp->handle, fmt, &mpscp, file.c_str());
                 } catch (std::string s){
@@ -835,7 +835,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info = {nullptr, sender, fn};
-                TermHookGuard hookguard{&info};
+                TermHookThreadGuard hookguard{&info};
                 try {
                     glp_intopt_start(lp->handle, &ctx);
                     while(!ctx.done) {
@@ -913,7 +913,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     ret = glp_read_lp(lp->handle, NULL, file.c_str());
                 } catch (std::string s){
@@ -971,7 +971,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     ret = glp_write_lp(lp->handle, NULL, file.c_str());
                 } catch (std::string s){
@@ -1084,7 +1084,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     ret = glp_print_ranges(lp->handle, len, list, flags, file.c_str());
                 } catch (std::string s){
@@ -1215,7 +1215,7 @@ namespace NodeGLPK {
 
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     glp_scale_prob(lp->handle, param);
                 } catch (std::string s){
@@ -1254,7 +1254,7 @@ namespace NodeGLPK {
             }
             virtual void ExecuteWithEmitter(const ExecutionProgressSender* sender, eventemitter_fn_r fn) override {
                 HookInfo info {nullptr, sender, fn};
-                TermHookGuard hookguard{&lp->info_};
+                TermHookThreadGuard hookguard{&lp->info_};
                 try {
                     ret = glp_factorize(lp->handle);
                 } catch (std::string s){

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -223,10 +223,13 @@ namespace NodeGLPK {
             return true;
         }
     private:
-        explicit Problem(): node::ObjectWrap(), emitter_(std::make_shared<NodeEvent::EventEmitter>()), info_{emitter_, nullptr, nullptr}  {
-            TermHookGuard hookguard{&info_};
-            handle = glp_create_prob();
-            thread = false;
+       explicit Problem()
+           : node::ObjectWrap(),
+             emitter_(std::make_shared<NodeEvent::EventEmitter>()),
+             info_{std::make_shared<HookInfo>(emitter_, nullptr, nullptr)} {
+           TermHookGuard hookguard{info_};
+           handle = glp_create_prob();
+           thread = false;
         }
 
         ~Problem(){
@@ -276,7 +279,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&lp->info_};
+            TermHookGuard hookguard{lp->info_};
             GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(), pia, pja, par);)
 
             
@@ -294,7 +297,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{&lp->info_};
+                      TermHookGuard hookguard{lp->info_};
                       glp_init_smcp(&scmp);
                       if (info.Length() == 1)
                           if (!SmcpInit(&scmp, info[0])) return;
@@ -309,7 +312,7 @@ namespace NodeGLPK {
             SimplexWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
 
-                TermHookGuard hookguard{&lp->info_};
+                TermHookGuard hookguard{lp->info_};
                 glp_init_smcp(&smcp);
                 lp->emitter_->emit("initialized", "Complete");
             }
@@ -359,7 +362,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{&lp->info_};
+                      TermHookGuard hookguard{lp->info_};
                       glp_init_smcp(&scmp);
                       if (info.Length() == 1) {
                           if (info[0]->IsObject())
@@ -375,7 +378,7 @@ namespace NodeGLPK {
         public:
             ExactWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
-                TermHookGuard hookguard{&lp->info_};
+                TermHookGuard hookguard{lp->info_};
                 glp_init_smcp(&smcp);
             }
             void WorkComplete() {
@@ -448,7 +451,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{&lp->info_};
+                      TermHookGuard hookguard{lp->info_};
                       glp_init_iptcp(&iptcp);
                       if (info.Length() == 1)
                          if (!IptcpInit(&iptcp, info[0])) return;
@@ -461,7 +464,7 @@ namespace NodeGLPK {
         public:
             InteriorWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
-                TermHookGuard hookguard{&lp->info_};
+                TermHookGuard hookguard{lp->info_};
                 glp_init_iptcp(&iptcp);
             }
             void WorkComplete() {
@@ -540,7 +543,7 @@ namespace NodeGLPK {
                 V8CHECK(!lp->handle, "object deleted");
                 V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                TermHookGuard hookguard{&lp->info_};
+                TermHookGuard hookguard{lp->info_};
                 glp_init_mpscp(&mpscp);
                 if (info.Length() == 1)
                     if (!MpscpInit(&mpscp, info[0])) return;
@@ -556,7 +559,7 @@ namespace NodeGLPK {
         public:
             ReadMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
             : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
-                TermHookGuard hookguard{&lp->info_};
+                TermHookGuard hookguard{lp->info_};
                 glp_init_mpscp(&mpscp);
             }
             
@@ -618,7 +621,7 @@ namespace NodeGLPK {
               V8CHECK(!lp->handle, "object deleted");
               V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-              TermHookGuard hookguard{&lp->info_};
+              TermHookGuard hookguard{lp->info_};
               glp_init_mpscp(&mpscp);
               if (info.Length() == 1)
                 if (!MpscpInit(&mpscp, info[0])) return;
@@ -632,7 +635,7 @@ namespace NodeGLPK {
         public:
             WriteMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
             : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
-                TermHookGuard hookguard{&lp->info_};
+                TermHookGuard hookguard{lp->info_};
                 glp_init_mpscp(&mpscp);
             }
             
@@ -798,7 +801,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{&lp->info_};
+                      TermHookGuard hookguard{lp->info_};
                       glp_init_iocp(&iocp);
                       if (info.Length() == 1)
                           if (!IocpInit(&iocp, info[0])) return;
@@ -814,7 +817,7 @@ namespace NodeGLPK {
         public:
             IntoptWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
-                TermHookGuard hookguard{&lp->info_};
+                TermHookGuard hookguard{lp->info_};
                 glp_init_iocp(&parm);
                 glp_init_mip_ctx(&ctx);
                 ctx.parm = &parm;
@@ -886,7 +889,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&lp->info_};
+            TermHookGuard hookguard{lp->info_};
             info.GetReturnValue().Set(glp_read_lp(lp->handle, NULL, V8TOCSTRING(info[0])));
         }
         
@@ -941,7 +944,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&lp->info_};
+            TermHookGuard hookguard{lp->info_};
             GLP_CATCH_RET(info.GetReturnValue().Set(glp_write_lp(lp->handle, NULL, V8TOCSTRING(info[0])));)
         }
         
@@ -998,7 +1001,7 @@ namespace NodeGLPK {
             double ae_max, re_max;
             int ae_ind, re_ind;
 
-            TermHookGuard hookguard{&lp->info_};
+            TermHookGuard hookguard{lp->info_};
             GLP_CATCH_RET(glp_check_kkt(lp->handle, info[0]->Int32Value(), info[1]->Int32Value(), &ae_max, &ae_ind, &re_max, &re_ind);)
             
             Nan::Callback* cb = new Nan::Callback(Local<Function>::Cast(info[2]));
@@ -1025,7 +1028,7 @@ namespace NodeGLPK {
             uint32_t count = 0;
             int* plist = NULL;
             int ret = 0;
-            TermHookGuard hookguard{&lp->info_};
+            TermHookGuard hookguard{lp->info_};
             GLP_CATCH(
                 if (info[0]->IsInt32Array()) {
                     Local<Int32Array> list = Local<Int32Array>::Cast(info[0]);
@@ -1113,7 +1116,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&lp->info_};
+            TermHookGuard hookguard{lp->info_};
             GLP_CATCH_RET(
                 glp_bfcp bfcp;
                 glp_get_bfcp(lp->handle, &bfcp);
@@ -1138,7 +1141,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&lp->info_};
+            TermHookGuard hookguard{lp->info_};
             GLP_CATCH_RET(
                       glp_bfcp bfcp;
                       glp_get_bfcp(lp->handle, &bfcp);
@@ -1490,7 +1493,7 @@ namespace NodeGLPK {
         static Nan::Persistent<FunctionTemplate> constructor;
 
         std::shared_ptr<NodeEvent::EventEmitter> emitter_;
-        HookInfo info_;
+        std::shared_ptr<HookInfo> info_;
     public:
         glp_prob *handle;
         std::atomic<bool> thread;

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -24,6 +24,7 @@ namespace NodeGLPK {
             tpl->InstanceTemplate()->SetInternalFieldCount(1);
             
             // prototypes
+            Nan::SetPrototypeMethod(tpl, "on", On);
             Nan::SetPrototypeMethod(tpl, "reason", Reason);
             Nan::SetPrototypeMethod(tpl, "terminate", Terminate);
             Nan::SetPrototypeMethod(tpl, "treeSize", TreeSize);
@@ -69,6 +70,19 @@ namespace NodeGLPK {
                       obj->Wrap(info.This());
                       info.GetReturnValue().Set(info.This());
             )
+        }
+
+        static NAN_METHOD(On) {
+            V8CHECK(info.Length() != 2, "Wrong number of arguments");
+            V8CHECK(!(info[0]->IsString() || !info[1]->IsFunction()), "Wrong arguments");
+
+            Tree* tree = ObjectWrap::Unwrap<Tree>(info.Holder());
+            V8CHECK(!tree->handle, "object deleted");
+
+            auto s = std::string(*v8::String::Utf8Value(info[0]->ToString()));
+            Nan::Callback* callback = new Nan::Callback(info[1].As<Function>());
+
+            tree->emitter_->on(s, callback);
         }
         
         GLP_BIND_VALUE(Tree, Reason, glp_ios_reason);

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -59,7 +59,10 @@ namespace NodeGLPK {
             return ret;
         }
     private:
-        explicit Tree(): node::ObjectWrap(), emitter_(std::make_shared<NodeEvent::EventEmitter>()), info_{emitter_,nullptr,nullptr} {}
+       explicit Tree()
+           : node::ObjectWrap(),
+             emitter_(std::make_shared<NodeEvent::EventEmitter>()),
+             info_{std::make_shared<HookInfo>(emitter_, nullptr, nullptr)} {}
         ~Tree(){};
         
         static NAN_METHOD(New) {
@@ -94,7 +97,7 @@ namespace NodeGLPK {
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread.load(), "an async operation is inprogress");
           
-            TermHookGuard hookguard{&host->info_};
+            TermHookGuard hookguard{host->info_};
             int a_cnt, n_cnt, t_cnt;
             GLP_CATCH_RET(glp_ios_tree_size(host->handle, &a_cnt, &n_cnt, &t_cnt);)
             Local<Object> ret = Nan::New<Object>();
@@ -129,7 +132,7 @@ namespace NodeGLPK {
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&host->info_};
+            TermHookGuard hookguard{host->info_};
             glp_attr attr;
             GLP_CATCH_RET(glp_ios_row_attr(host->handle, info[0]->Int32Value(), &attr);)
             
@@ -152,7 +155,7 @@ namespace NodeGLPK {
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&tree->info_};
+            TermHookGuard hookguard{tree->info_};
 
             Local<Int32Array> ind = Local<Int32Array>::Cast(info[3]);
             Local<Float64Array> val = Local<Float64Array>::Cast(info[4]);
@@ -194,7 +197,7 @@ namespace NodeGLPK {
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{&tree->info_};
+            TermHookGuard hookguard{tree->info_};
             Local<Float64Array> x = Local<Float64Array>::Cast(info[0]);
             
             int count = (int)x->Length();
@@ -207,7 +210,7 @@ namespace NodeGLPK {
         }
     private:
         std::shared_ptr<NodeEvent::EventEmitter> emitter_;
-        HookInfo info_;
+        std::shared_ptr<HookInfo> info_;
         
     public:
         static Nan::Persistent<FunctionTemplate> constructor;

--- a/test/eventstream-test.js
+++ b/test/eventstream-test.js
@@ -1,6 +1,6 @@
 'use strict;'
 
-const expect = require('chai').expect
+const expect = require('code').expect
 const testRoot = require('path').resolve(__dirname, '..')
 const glp = require('bindings')({ module_root: testRoot, bindings: 'glpk' })
 const temp = require('temp').track()

--- a/test/eventstream-test.js
+++ b/test/eventstream-test.js
@@ -1,0 +1,129 @@
+'use strict;'
+
+const expect = require('chai').expect
+const testRoot = require('path').resolve(__dirname, '..')
+const glp = require('bindings')({ module_root: testRoot, bindings: 'glpk' })
+const temp = require('temp').track()
+const fs = require('fs')
+
+glp.termOutput(false)
+
+describe('Verify eventemitter on Problem object', function() {
+    it('should have log events fired as the problem is processed asynchronously', function(done) {
+        let lp = new glp.Problem()
+        let idx = 0;
+        let messages = [
+            "GLPK Integer Optimizer",
+            "0 rows, 0 columns, 0 non-zeros",
+            "0 integer variables, none of which are binary",
+            "Preprocessing...",
+            "Objective value =   0.000000000e+00",
+            "INTEGER OPTIMAL SOLUTION FOUND BY MIP PREPROCESSOR",
+        ]
+        lp.on('log', function(msg) {
+            expect(msg).to.contain(messages[idx++])
+            if(idx === messages.length) {
+                done()
+            }
+        })
+        lp.intopt({ msgLev: glp.MSG_ALL, presolve: glp.ON }, function() {
+        })
+
+    })
+
+    it('should have log events fired as the problem is processed synchronously', function(done) {
+        let lp = new glp.Problem()
+        let idx = 0;
+        let messages = [
+            "GLPK Integer Optimizer",
+            "0 rows, 0 columns, 0 non-zeros",
+            "0 integer variables, none of which are binary",
+            "Preprocessing...",
+            "Objective value =   0.000000000e+00",
+            "INTEGER OPTIMAL SOLUTION FOUND BY MIP PREPROCESSOR",
+        ]
+        lp.on('log', function(msg) {
+            expect(msg).to.contain(messages[idx++])
+        })
+        lp.intoptSync({ msgLev: glp.MSG_ALL, presolve: glp.ON })
+        expect(idx).to.equal(messages.length)
+        done()
+    })
+})
+
+describe('Verify eventemitter on mathprog', function() {
+    it('should have log events fired as the prog is processed asynchronously', function(done) {
+        temp.open('mathprog_test_tempfile', function(err, info) {
+            fs.write(info.fd,
+                    'param e := 20;\n' +
+                    'set Sample := {1..2**e-1};\n' +
+                    '\n' +
+                    'var Mean;\n' +
+                    'var E{z in Sample};\n' +
+                    '\n' +
+                    '/* sum of variances is zero */\n' +
+                    'zumVariance: sum{z in Sample} E[z] = 0;\n' +
+                    '\n' +
+                    '/* Mean + variance[n] = Sample[n] */\n' +
+                    'variances{z in Sample}: Mean + E[z] = z;\n' +
+                    '\n' +
+                    'solve;\n' +
+                    '\n' +
+                    'end;\n');
+
+            let mp = new glp.Mathprog()
+            let idx = 0
+            let messages = [
+                'Reading model section from ' + info.path,
+                '15 lines were read',
+            ]
+
+
+            mp.on('log', function(msg) {
+                expect(msg).to.contain(messages[idx++])
+                if(idx === messages.length) {
+                    done()
+                }
+            })
+
+            mp.readModel(info.path, 0, function() {
+            })
+        })
+    })
+
+    it('should have log events fired as the prog is processed synchronously', function(done) {
+        temp.open('mathprog_test_tempfile', function(err, info) {
+            fs.write(info.fd,
+                    'param e := 20;\n' +
+                    'set Sample := {1..2**e-1};\n' +
+                    '\n' +
+                    'var Mean;\n' +
+                    'var E{z in Sample};\n' +
+                    '\n' +
+                    'zumVariance: sum{z in Sample} E[z] = 0;\n' +
+                    '\n' +
+                    'variances{z in Sample}: Mean + E[z] = z;\n' +
+                    '\n' +
+                    'solve;\n' +
+                    '\n' +
+                    'end;\n');
+
+            let mp = new glp.Mathprog()
+            let idx = 0
+            let messages = [
+                'Reading model section from ' + info.path,
+                '13 lines were read',
+            ]
+
+
+            mp.on('log', function(msg) {
+                expect(msg).to.contain(messages[idx++])
+            })
+
+            mp.readModelSync(info.path, 0)
+            expect(idx).to.equal(messages.length)
+            done()
+        })
+    })
+})
+

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -254,7 +254,7 @@ describe("Test glp_intopt_start, glp_intopt_run, glp_intopt_stop flow", function
             let lp = new glp.Problem();
 
             lp.readLp(info.path, function(err, ret){
-                let calledCallback = false
+                let calledCallback = 0
 
                 lp.scale(glp.SF_AUTO, function(err){
                     expect(err).to.be.undefined
@@ -263,13 +263,13 @@ describe("Test glp_intopt_start, glp_intopt_run, glp_intopt_stop flow", function
                         expect(err).to.be.undefined
                         if (lp.getNumInt() > 0){
                             function callback(tree){
-                                calledCallback = true
+                                calledCallback += 1
                             }
 
                             lp.intopt({cbFunc: callback}, function(err, ret){
                                 expect(err).to.be.null
                                 expect(lp.mipObjVal()).to.equal(4190215)
-                                expect(calledCallback).to.be.true
+                                expect(calledCallback).to.equal(27450)
                                 done()
                             });
                         }

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -199,7 +199,7 @@ describe("Factorize problem tests", function() {
 })
 
 describe("Test glp_intopt_start, glp_intopt_run, glp_intopt_stop flow", function() {
-    it("should invoke the callback iteratively toward sollution", function(done) {
+    it("should invoke the callback iteratively toward solution", function(done) {
         this.timeout(30000)
         temp.open('mathprog_test_tempfile', function(err, info) {
             fs.write(info.fd,

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -1,0 +1,292 @@
+'use strict;'
+
+const expect = require('chai').expect
+const testRoot = require('path').resolve(__dirname, '..')
+const glp = require('bindings')({ module_root: testRoot, bindings: 'glpk' })
+
+glp.termOutput(false)
+
+function nearly(n, magnitude) {
+    if(!magnitude) {
+        magnitude = 1000000000000
+    }
+    return [ n - 1/magnitude, n + 1/magnitude ]
+}
+
+describe("Simplex problem tests", function() {
+    it('should get the correct answer', function(done) {
+        this.timeout(10000)
+        let lp = new glp.Problem()
+        lp.setProbName("sample")
+        lp.setObjDir(glp.MAX)
+
+        lp.addRows(3)
+        lp.setRowName(1, "p")
+        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
+        lp.setRowName(2, "q")
+        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
+        lp.setRowName(3, "r")
+        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
+
+        lp.addCols(3)
+        lp.setColName(1, "x1")
+        lp.setColBnds(1, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(1, 10.0)
+        lp.setColName(2, "x2")
+        lp.setColBnds(2, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(2, 6.0)
+        lp.setColName(3, "x2")
+        lp.setColBnds(3, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(3, 4.0)
+
+        let ia = new Int32Array(10);
+        let ja = new Int32Array(10);
+        let ar = new Float64Array(10);
+        
+        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
+        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
+        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
+        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
+        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
+        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
+        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
+        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
+        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
+
+        lp.loadMatrix(9, ia, ja, ar)
+        lp.simplex({}, function() {
+            let z = lp.getObjVal()
+            let x1 = lp.getColPrim(1)
+            let x2 = lp.getColPrim(2)
+            let x3 = lp.getColPrim(3)
+
+            expect(z).to.be.within(...(nearly(733 + 1/3)))
+            expect(x1).to.be.within(...(nearly(33 + 1/3)))
+            expect(x2).to.be.within(...(nearly(66 + 2/3)))
+            expect(x3).to.equal(0)
+            done()
+        })
+    });
+})
+
+describe("Exact problem tests", function() {
+    it('should get the correct answer', function(done) {
+        this.timeout(10000)
+        let lp = new glp.Problem()
+        lp.setProbName("sample")
+        lp.setObjDir(glp.MAX)
+
+        lp.addRows(3)
+        lp.setRowName(1, "p")
+        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
+        lp.setRowName(2, "q")
+        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
+        lp.setRowName(3, "r")
+        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
+
+        lp.addCols(3)
+        lp.setColName(1, "x1")
+        lp.setColBnds(1, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(1, 10.0)
+        lp.setColName(2, "x2")
+        lp.setColBnds(2, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(2, 6.0)
+        lp.setColName(3, "x2")
+        lp.setColBnds(3, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(3, 4.0)
+
+        let ia = new Int32Array(10);
+        let ja = new Int32Array(10);
+        let ar = new Float64Array(10);
+        
+        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
+        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
+        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
+        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
+        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
+        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
+        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
+        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
+        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
+
+        lp.loadMatrix(9, ia, ja, ar)
+        lp.exact({}, function() {
+            let z = lp.getObjVal()
+            let x1 = lp.getColPrim(1)
+            let x2 = lp.getColPrim(2)
+            let x3 = lp.getColPrim(3)
+
+            expect(z).to.equal(733 + 1/3)
+            expect(x1).to.equal(33 + 1/3)
+            expect(x2).to.equal(66 + 2/3)
+            expect(x3).to.equal(0)
+            done()
+        })
+    });
+})
+
+
+describe("Intopt problem tests", function() {
+    it('should get the correct answer', function(done) {
+        this.timeout(10000)
+        let lp = new glp.Problem()
+        lp.setProbName("sample")
+        lp.setObjDir(glp.MAX)
+
+        lp.addRows(3)
+        lp.setRowName(1, "p")
+        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
+        lp.setRowName(2, "q")
+        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
+        lp.setRowName(3, "r")
+        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
+
+        lp.addCols(3)
+        lp.setColName(1, "x1")
+        lp.setColBnds(1, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(1, 10.0)
+        lp.setColName(2, "x2")
+        lp.setColBnds(2, glp.LO, 10.0, 0.0);
+        lp.setObjCoef(2, 6.0)
+        lp.setColKind(2, glp.IV)
+        lp.setColName(3, "x2")
+        lp.setColBnds(3, glp.LO, 10.0, 0.0);
+        lp.setObjCoef(3, 4.0)
+        lp.setColKind(3, glp.IV)
+
+        let ia = new Int32Array(10);
+        let ja = new Int32Array(10);
+        let ar = new Float64Array(10);
+        
+        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
+        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
+        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
+        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
+        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
+        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
+        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
+        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
+        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
+
+        lp.loadMatrix(9, ia, ja, ar)
+        lp.simplex({}, function() {
+            lp.intopt({},function() {
+                let z = lp.mipObjVal()
+                let x1 = lp.mipColVal(1)
+                let x2 = lp.mipColVal(2)
+                let x3 = lp.mipColVal(3)
+
+                expect(z).to.equal(706)
+                expect(x1).to.be.within(...(nearly(31.8)))
+                expect(x2).to.equal(58)
+                expect(x3).to.equal(10)
+                done()
+            })
+        })
+    });
+})
+
+describe("Interior point problem tests", function() {
+    it('should get the correct answer', function(done) {
+        this.timeout(10000)
+        let lp = new glp.Problem()
+        lp.setProbName("sample")
+        lp.setObjDir(glp.MAX)
+
+        lp.addRows(3)
+        lp.setRowName(1, "p")
+        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
+        lp.setRowName(2, "q")
+        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
+        lp.setRowName(3, "r")
+        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
+
+        lp.addCols(3)
+        lp.setColName(1, "x1")
+        lp.setColBnds(1, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(1, 10.0)
+        lp.setColName(2, "x2")
+        lp.setColBnds(2, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(2, 6.0)
+        lp.setColName(3, "x2")
+        lp.setColBnds(3, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(3, 4.0)
+
+        let ia = new Int32Array(10);
+        let ja = new Int32Array(10);
+        let ar = new Float64Array(10);
+        
+        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
+        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
+        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
+        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
+        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
+        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
+        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
+        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
+        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
+
+        lp.loadMatrix(9, ia, ja, ar)
+        lp.interior({}, function() {
+            let z = lp.iptObjVal()
+            let x1 = lp.iptColPrim(1)
+            let x2 = lp.iptColPrim(2)
+            let x3 = lp.iptColPrim(3)
+
+            expect(z).to.be.within(...nearly(733 + 1/3, 10000))
+            expect(x1).to.be.within(...(nearly(33 + 1/3, 10000)))
+            expect(x2).to.be.within(...(nearly(66 + 2/3, 10000)))
+            expect(x3).to.be.within(...(nearly(0, 1000000)))
+            done()
+        })
+    });
+})
+
+describe("Factorize problem tests", function() {
+    it('should get the correct answer', function(done) {
+        this.timeout(10000)
+        let lp = new glp.Problem()
+        lp.setProbName("sample")
+        lp.setObjDir(glp.MAX)
+
+        lp.addRows(3)
+        lp.setRowName(1, "p")
+        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
+        lp.setRowName(2, "q")
+        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
+        lp.setRowName(3, "r")
+        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
+
+        lp.addCols(3)
+        lp.setColName(1, "x1")
+        lp.setColBnds(1, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(1, 10.0)
+        lp.setColName(2, "x2")
+        lp.setColBnds(2, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(2, 6.0)
+        lp.setColName(3, "x2")
+        lp.setColBnds(3, glp.LO, 0.0, 0.0);
+        lp.setObjCoef(3, 4.0)
+
+        let ia = new Int32Array(10);
+        let ja = new Int32Array(10);
+        let ar = new Float64Array(10);
+        
+        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
+        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
+        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
+        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
+        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
+        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
+        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
+        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
+        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
+
+        lp.loadMatrix(9, ia, ja, ar)
+        expect(lp.bfExists()).to.equal(0);
+        lp.factorize(function() {
+            expect(lp.bfExists()).to.equal(1);
+            done()
+        })
+    });
+})

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -13,53 +13,61 @@ function nearly(n, magnitude) {
     return [ n - 1/magnitude, n + 1/magnitude ]
 }
 
+function setupSimplexLP() {
+    // LP inspired by sample.c in the glpk distribution
+    let lp = new glp.Problem()
+    lp.setProbName("sample")
+    lp.setObjDir(glp.MAX)
+
+    lp.addRows(3)
+    lp.setRowName(1, "p")
+    lp.setRowBnds(1, glp.UP, 0.0, 100.0)
+    lp.setRowName(2, "q")
+    lp.setRowBnds(2, glp.UP, 0.0, 600.0)
+    lp.setRowName(3, "r")
+    lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
+
+    lp.addCols(3)
+    lp.setColName(1, "x1")
+    lp.setColBnds(1, glp.LO, 0.0, 0.0);
+    lp.setObjCoef(1, 10.0)
+    lp.setColName(2, "x2")
+    lp.setColBnds(2, glp.LO, 0.0, 0.0);
+    lp.setObjCoef(2, 6.0)
+    lp.setColName(3, "x2")
+    lp.setColBnds(3, glp.LO, 0.0, 0.0);
+    lp.setObjCoef(3, 4.0)
+
+    let ia = new Int32Array(10);
+    let ja = new Int32Array(10);
+    let ar = new Float64Array(10);
+
+    ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
+    ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
+    ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
+    ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
+    ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
+    ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
+    ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
+    ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
+    ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
+
+    lp.loadMatrix(9, ia, ja, ar)
+
+    return lp
+}
+
 describe("Simplex problem tests", function() {
     it('should get the correct answer', function(done) {
         this.timeout(10000)
-        let lp = new glp.Problem()
-        lp.setProbName("sample")
-        lp.setObjDir(glp.MAX)
-
-        lp.addRows(3)
-        lp.setRowName(1, "p")
-        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
-        lp.setRowName(2, "q")
-        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
-        lp.setRowName(3, "r")
-        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
-
-        lp.addCols(3)
-        lp.setColName(1, "x1")
-        lp.setColBnds(1, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(1, 10.0)
-        lp.setColName(2, "x2")
-        lp.setColBnds(2, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(2, 6.0)
-        lp.setColName(3, "x2")
-        lp.setColBnds(3, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(3, 4.0)
-
-        let ia = new Int32Array(10);
-        let ja = new Int32Array(10);
-        let ar = new Float64Array(10);
-        
-        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
-        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
-        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
-        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
-        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
-        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
-        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
-        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
-        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
-
-        lp.loadMatrix(9, ia, ja, ar)
+        lp = setupSimplexLP()
         lp.simplex({}, function() {
             let z = lp.getObjVal()
             let x1 = lp.getColPrim(1)
             let x2 = lp.getColPrim(2)
             let x3 = lp.getColPrim(3)
 
+            expect(lp.getStatus()).to.equal(glp.OPT)
             expect(z).to.be.within(...(nearly(733 + 1/3)))
             expect(x1).to.be.within(...(nearly(33 + 1/3)))
             expect(x2).to.be.within(...(nearly(66 + 2/3)))
@@ -72,50 +80,14 @@ describe("Simplex problem tests", function() {
 describe("Exact problem tests", function() {
     it('should get the correct answer', function(done) {
         this.timeout(10000)
-        let lp = new glp.Problem()
-        lp.setProbName("sample")
-        lp.setObjDir(glp.MAX)
-
-        lp.addRows(3)
-        lp.setRowName(1, "p")
-        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
-        lp.setRowName(2, "q")
-        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
-        lp.setRowName(3, "r")
-        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
-
-        lp.addCols(3)
-        lp.setColName(1, "x1")
-        lp.setColBnds(1, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(1, 10.0)
-        lp.setColName(2, "x2")
-        lp.setColBnds(2, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(2, 6.0)
-        lp.setColName(3, "x2")
-        lp.setColBnds(3, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(3, 4.0)
-
-        let ia = new Int32Array(10);
-        let ja = new Int32Array(10);
-        let ar = new Float64Array(10);
-        
-        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
-        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
-        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
-        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
-        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
-        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
-        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
-        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
-        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
-
-        lp.loadMatrix(9, ia, ja, ar)
+        let lp = setupSimplexLP()
         lp.exact({}, function() {
             let z = lp.getObjVal()
             let x1 = lp.getColPrim(1)
             let x2 = lp.getColPrim(2)
             let x3 = lp.getColPrim(3)
 
+            expect(lp.getStatus()).to.equal(glp.OPT)
             expect(z).to.equal(733 + 1/3)
             expect(x1).to.equal(33 + 1/3)
             expect(x2).to.equal(66 + 2/3)
@@ -129,6 +101,8 @@ describe("Exact problem tests", function() {
 describe("Intopt problem tests", function() {
     it('should get the correct answer', function(done) {
         this.timeout(10000)
+        // LP inspired by sample.c in the glpk distribution
+        // modified for MIP; sets 2 columns to integer values
         let lp = new glp.Problem()
         lp.setProbName("sample")
         lp.setObjDir(glp.MAX)
@@ -176,6 +150,7 @@ describe("Intopt problem tests", function() {
                 let x2 = lp.mipColVal(2)
                 let x3 = lp.mipColVal(3)
 
+                expect(lp.mipStatus()).to.equal(glp.OPT)
                 expect(z).to.equal(706)
                 expect(x1).to.be.within(...(nearly(31.8)))
                 expect(x2).to.equal(58)
@@ -189,50 +164,16 @@ describe("Intopt problem tests", function() {
 describe("Interior point problem tests", function() {
     it('should get the correct answer', function(done) {
         this.timeout(10000)
-        let lp = new glp.Problem()
-        lp.setProbName("sample")
-        lp.setObjDir(glp.MAX)
-
-        lp.addRows(3)
-        lp.setRowName(1, "p")
-        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
-        lp.setRowName(2, "q")
-        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
-        lp.setRowName(3, "r")
-        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
-
-        lp.addCols(3)
-        lp.setColName(1, "x1")
-        lp.setColBnds(1, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(1, 10.0)
-        lp.setColName(2, "x2")
-        lp.setColBnds(2, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(2, 6.0)
-        lp.setColName(3, "x2")
-        lp.setColBnds(3, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(3, 4.0)
-
-        let ia = new Int32Array(10);
-        let ja = new Int32Array(10);
-        let ar = new Float64Array(10);
-        
-        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
-        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
-        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
-        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
-        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
-        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
-        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
-        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
-        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
-
-        lp.loadMatrix(9, ia, ja, ar)
+        // LP inspired by sample.c in the glpk distribution
+        // Same as simplex LP
+        let lp = setupSimplexLP()
         lp.interior({}, function() {
             let z = lp.iptObjVal()
             let x1 = lp.iptColPrim(1)
             let x2 = lp.iptColPrim(2)
             let x3 = lp.iptColPrim(3)
 
+            expect(lp.iptStatus()).to.equal(glp.OPT)
             expect(z).to.be.within(...nearly(733 + 1/3, 10000))
             expect(x1).to.be.within(...(nearly(33 + 1/3, 10000)))
             expect(x2).to.be.within(...(nearly(66 + 2/3, 10000)))
@@ -245,44 +186,8 @@ describe("Interior point problem tests", function() {
 describe("Factorize problem tests", function() {
     it('should get the correct answer', function(done) {
         this.timeout(10000)
-        let lp = new glp.Problem()
-        lp.setProbName("sample")
-        lp.setObjDir(glp.MAX)
-
-        lp.addRows(3)
-        lp.setRowName(1, "p")
-        lp.setRowBnds(1, glp.UP, 0.0, 100.0)
-        lp.setRowName(2, "q")
-        lp.setRowBnds(2, glp.UP, 0.0, 600.0)
-        lp.setRowName(3, "r")
-        lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
-
-        lp.addCols(3)
-        lp.setColName(1, "x1")
-        lp.setColBnds(1, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(1, 10.0)
-        lp.setColName(2, "x2")
-        lp.setColBnds(2, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(2, 6.0)
-        lp.setColName(3, "x2")
-        lp.setColBnds(3, glp.LO, 0.0, 0.0);
-        lp.setObjCoef(3, 4.0)
-
-        let ia = new Int32Array(10);
-        let ja = new Int32Array(10);
-        let ar = new Float64Array(10);
-        
-        ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
-        ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
-        ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
-        ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
-        ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
-        ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
-        ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
-        ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
-        ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
-
-        lp.loadMatrix(9, ia, ja, ar)
+        // LP inspired by sample.c in the glpk distribution
+        let lp = setupSimplexLP()
         expect(lp.bfExists()).to.equal(0);
         lp.factorize(function() {
             expect(lp.bfExists()).to.equal(1);

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -1,6 +1,6 @@
 'use strict;'
 
-const expect = require('chai').expect
+const expect = require('code').expect
 const testRoot = require('path').resolve(__dirname, '..')
 const glp = require('bindings')({ module_root: testRoot, bindings: 'glpk' })
 const temp = require('temp').track()

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -201,7 +201,7 @@ describe("Factorize problem tests", function() {
 describe("Test glp_intopt_start, glp_intopt_run, glp_intopt_stop flow", function() {
     it("should invoke the callback iteratively toward solution", function(done) {
         this.timeout(10000)
-        temp.open('mathprog_test_tempfile', function(err, info) {
+        temp.open('glp_intopt_test_input', function(err, info) {
             fs.write(info.fd,
                 'Maximize\n' + 
                 'obj: + 786433 x1 + 655361 x2 + 589825 x3 + 557057 x4\n' + 

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -200,7 +200,7 @@ describe("Factorize problem tests", function() {
 
 describe("Test glp_intopt_start, glp_intopt_run, glp_intopt_stop flow", function() {
     it("should invoke the callback iteratively toward solution", function(done) {
-        this.timeout(30000)
+        this.timeout(10000)
         temp.open('mathprog_test_tempfile', function(err, info) {
             fs.write(info.fd,
                 'Maximize\n' + 


### PR DESCRIPTION
Replace existing term_hook with an aggregate hook, and add an
eventEmitter hook to that set. Then update everywhere glpk code runs
(that would potentially log) to switch the current thread's callback
and emitter (info) to the correct struct for the thing executing on the
thread. So that all log messages get shipped to for the 'log' event.


For review:

The EventEmitter piece ( https://github.com/TakeScoop/cpp-eventemitter )
Allows you to implement Native C++ code that behaves like an
EventEmitter. Users of a native module will be able to write
code like:

```javascript
foo = new NativeExtension();
foo.on("some event", function(value) {
	console.log(value);
})
```

And inside your native code, you will be able to emit events as they
happen, which will trigger the appropriate callbacks in javascript. The
emit occurs in a separate thread from your AsyncWorker, and so will not
appreciably block the work being done.

As a high-level explanation of EventEmitter. I'll first give a
super-high-level view of v8/Nan:

v8 has a bunch of data structures and functions which are not
thread-safe that can only be touched from the event loop on the "main"
thread. If you want anything to happen on the main thread, you schedule
it via `uv_async_send`, passing a `uv_async_t*` to it with the callback
you want executed on the main thread. Only in the context of that
callback can you do anything that touches v8/javascript.

A Native extension does work in an AsyncWorker. An AsyncWorker executes
the `Execute()` method in a separate thread, and so cannot directly do
anything that interfaces with javascript.

So, to allow native code to interface with javascript callbacks as
events happen, I provide an AsyncQueuedProgressWorker base class, which
relies on a shared ringbuffer to pass events into a callback that runs
on the main thread. The callback then does the work of dequeuing it and
shipping the event into javascript and calling the js callback.

To allow C code to invoke the emitter, I provide a specialization of
AsyncQueuedProgressWorker which provides a C emitter function. I also
provide a specialization which uses a reentrant emitter, for use in
multi-threaded C code.

To review this, start by first reviewing
https://github.com/TakeScoop/cpp-eventemitter

A tour of this change:

GLPK implements something called an environment, ( `src/glpk/env/glpenv.h` )
which has within it the ability to store both a term_hook and info to
pass to that hook. It was originally meant to be thread-local
(`src/glpk/env/tls.c`) but that was not implemented at the time
(presumably due to lack of consistency in compiler support).

So the first thing to review there is the macro expansion for
thread_local I have defined there. I stole it from
https://stackoverflow.com/questions/18298280/how-to-declare-a-variable-as-thread-local-portably/18298965#18298965

To enable the environment, the macro `HAVE_ENV` must be defined, so it
has been added to the gyp files. While this doesn't show up as much of a
change in the diff, there are `#ifdef HAVE_ENV` guards littered throughout
the code that light up a whole host of new code-paths. I have gone
through all of them and didn't spot anything worrisome (to find them, I pulled the nearest version to the
version here and diff'd
( https://ftp.gnu.org/gnu/glpk/glpk-4.55.tar.gz ) upstream does NOT have
the `HAVE_ENV` guards, so they show up prominently in the diff). Rename
src/env/env.h to src/env/glpenv.h to avoid the newfile diffs, and
`find src -iname '*.c' -o -iname '*.h' | xargs perl -pi -e 's/"env\.h"/"glpenv.h"/g'`
to trim the noise. This is, by far, the most difficult part of this review.

However,  upon valgrind'ing, found quite a bit. I have fixed all I have found in later commits. So my solutions need to be confirmed (some huge things; I now have a GLOBAL_MEM_STATS guard for the environment dynamic memory allocator to collect usage statistics in. I also removed the to-be-free'd list structure as there is already pooling implemented elsewhere via dmp. Doing this resulted in some leaks, and some use-after-free bugs; those have been addressed. As of the current commit, the only leaks remaining are in node itself (presumably because the gc doesn't bother doing a pass before termination)

Next, ensure that every entrypoint has the env setup (
nodeglpk.hpp:NodeGLPK::TermHookManager#ThreadInitDefaultHooks which is
implicitely called from the CTOR of nodeglpk.hpp:NodeGLPK::TermHookGuard
So basically ensure everything uses TermHookGuard if it's in the main thread, and a TermHookThreadGuard if it's in a worker-thread.

~Also ensure TermHook(:?Thread)?Guards do not outlive their the info they set. This
is necessary to maintain thread consistency as different things do work
on potentially the same threads (the main thread in particular), and to
ensure there are no dangling pointers left on any thread.~  Made these shared_ptr to avoid the potential bugs

~Every Nan::AsyncWorkers becomes a ReentrantCWorker. Ensure that every
ReentrantCWorker's ExecuteWithEmitter has a TermHookThreadGuard in it and
appropriately scoped to have the correct lifetime.~ Doing this via decorator now, so just ensure everything is decorated (and that the decorated one is the one being run; I almost missed one that I know about)

Also, I switched all of the `bool thread` member variables to atomics
since they are read and written in seperate threads and could have
resulted in a race. Make sure that everywhere they are read is now a
'.load()'. `operator=` is overloaded, so assignment is fine as is. (no
need to require `.store()`)

Also, to build this before cpp-eventemitter is pushed to npmjs, comment
out cpp-eventemitter in package.json, clone
https://github.com/TakeScoop/cpp-eventemitter, and in the
cpp-eventemitter repo run `npm link`; then in this repo, with the same
version of npm, run `npm link cpp-eventemitter`... If you know an
easier way to do this, I'm happy to learn it.