### PR TITLE
Fix some buffer overruns I noticed

### DIFF
--- a/src/glpk/env/error.c
+++ b/src/glpk/env/error.c
@@ -63,7 +63,7 @@ static void errfunc(const char *fmt, ...)
     va_list arg;
     // format the output
     va_start(arg, fmt);
-    vsprintf(term_buf, fmt, arg);
+    vsnprintf(term_buf, TBUF_SIZE, fmt, arg);
     va_end(arg);
 
     if (_error_hook_){

--- a/src/glpk/env/stdout.c
+++ b/src/glpk/env/stdout.c
@@ -92,9 +92,8 @@ void glp_printf(const char *fmt, ...)
          goto skip;
       /* format the output */
       va_start(arg, fmt);
-      vsprintf(env->term_buf, fmt, arg);
       /* (do not use xassert) */
-      assert(strlen(env->term_buf) < TBUF_SIZE);
+      assert(vsnprintf(env->term_buf, TBUF_SIZE, fmt, arg) < TBUF_SIZE);
       va_end(arg);
       /* write the formatted output on the terminal */
       glp_puts(env->term_buf);
@@ -106,9 +105,8 @@ skip: return;
     if (!_term_hook_) return;
     // format the output
     va_start(arg, fmt);
-    vsprintf(term_buf, fmt, arg);
     // (do not use xassert)
-    assert(strlen(term_buf) < TBUF_SIZE);
+    assert(vsnprintf(term_buf, TBUF_SIZE, fmt, arg) < TBUF_SIZE);
     va_end(arg);
     // write the formatted output on the terminal
     glp_puts(term_buf);
@@ -138,9 +136,8 @@ void glp_vprintf(const char *fmt, va_list arg)
       if (!env->term_out)
          goto skip;
       /* format the output */
-      vsprintf(env->term_buf, fmt, arg);
       /* (do not use xassert) */
-      assert(strlen(env->term_buf) < TBUF_SIZE);
+      assert(vsnprintf(env->term_buf, TBUF_SIZE, fmt, arg) < TBUF_SIZE);
       /* write the formatted output on the terminal */
       glp_puts(env->term_buf);
 #else
@@ -148,9 +145,8 @@ void glp_vprintf(const char *fmt, va_list arg)
     // if terminal output is disabled, do nothing
     if (!_term_hook_) return;
     // format the output
-    vsprintf(term_buf, fmt, arg);
     // (do not use xassert)
-    assert(strlen(term_buf) < TBUF_SIZE);
+    assert(vsnprintf(env->term_buf, TBUF_SIZE, fmt, arg) < TBUF_SIZE);
     // write the formatted output on the terminal
     glp_puts(term_buf);
 #endif

--- a/src/glpk/env/stream.c
+++ b/src/glpk/env/stream.c
@@ -416,7 +416,7 @@ int glp_format(glp_file *f, const char *fmt, ...)
       if (!(f->flag & IOWRT))
          xerror("glp_format: attempt to write to input stream\n");
       va_start(arg, fmt);
-      nnn = vsprintf(env->term_buf, fmt, arg);
+      nnn = vsnprintf(env->term_buf, TBUF_SIZE, fmt, arg);
       xassert(0 <= nnn && nnn < TBUF_SIZE);
       va_end(arg);
       return nnn == 0 ? 0 : glp_write(f, env->term_buf, nnn);
@@ -427,7 +427,7 @@ int glp_format(glp_file *f, const char *fmt, ...)
     if (!(f->flag & IOWRT))
         xerror("glp_format: attempt to write to input stream\n");
     va_start(arg, fmt);
-    nnn = vsprintf(term_buf, fmt, arg);
+    nnn = vsnprintf(term_buf, TBUF_SIZE, fmt, arg);
     xassert(0 <= nnn && nnn < TBUF_SIZE);
     va_end(arg);
     return nnn == 0 ? 0 : glp_write(f, term_buf, nnn);


### PR DESCRIPTION
Both heap and stack overruns. There is an assert there to check that strlen says it only wrote a safe number of bytes; but if buffer had a \0 in it, and then other data afterwards, it could still continue execution after overrun. I doubt there is anywhere in this case where this actually matters, but just to be safe, I swapped them out for vsnprintf's. 