### PR TITLE
Per Problem memory statistics

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -42,6 +42,11 @@ static_cast<PropertyAttribute>(ReadOnly | DontDelete);\
 }\
 while (0)
 
+#define GLP_CREATE_HOOK_GUARDS(NAME) \
+    MemStatsGuard mguard{NAME->memstats_}; \
+    TermHookGuard hookguard{NAME->info_}
+
+
 #define GLP_BIND_VOID_STR(CLASS, NAME, API)\
 static NAN_METHOD(NAME) {\
     V8CHECK(info.Length() != 1, "Wrong number of arguments");\
@@ -51,8 +56,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, V8TOCSTRING(info[0]));)\
 }
 
@@ -62,8 +66,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(const char* name = API(host->handle);\
     if (name)\
         info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
@@ -80,8 +83,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value());)\
 }
 
@@ -91,8 +93,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle));)\
 }
 
@@ -105,8 +106,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1]));)\
 }
 
@@ -119,8 +119,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(const char* name = API(host->handle, info[0]->Int32Value());\
     if (name)\
         info.GetReturnValue().Set(Nan::New<String>(name).ToLocalChecked());\
@@ -138,8 +137,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value(),\
                      info[2]->NumberValue(), info[3]->NumberValue());)\
 }
@@ -153,8 +151,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->NumberValue());)\
 }
 
@@ -167,8 +164,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value()));)\
 }
 
@@ -194,8 +190,7 @@ static NAN_METHOD(NAME) {\
     for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();\
     for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), count, pja, par);)\
     \
     free(pja);\
@@ -211,8 +206,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     try{\
         int row = info[0]->Int32Value();\
         int count = API(host->handle, row, NULL, NULL);\
@@ -247,8 +241,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle);)\
 }
 
@@ -268,8 +261,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
     count--;\
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, count, idx);)\
     free(idx);\
 }
@@ -283,8 +275,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0])));)\
 }
 
@@ -297,8 +288,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value());)\
 }
 
@@ -311,8 +301,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1])));)\
 }
 
@@ -325,8 +314,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{host->memstats_}; \
-    TermHookGuard hookguard{host->info_}; \
+    GLP_CREATE_HOOK_GUARDS(host); \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0]), info[1]->Int32Value()));)\
 }
 
@@ -336,8 +324,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!obj->handle, "object already deleted");\
     V8CHECK(obj->thread, "an async operation is inprogress")\
     \
-    MemStatsGuard mguard{obj->memstats_}; \
-    TermHookGuard hookguard{obj->info_}; \
+    GLP_CREATE_HOOK_GUARDS(obj); \
     GLP_CATCH_RET(API(obj->handle);)\
     obj->handle = NULL;\
 }

--- a/src/common.h
+++ b/src/common.h
@@ -51,6 +51,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, V8TOCSTRING(info[0]));)\
 }
@@ -61,6 +62,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(const char* name = API(host->handle);\
     if (name)\
@@ -78,6 +80,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value());)\
 }
@@ -88,6 +91,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle));)\
 }
@@ -101,6 +105,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1]));)\
 }
@@ -114,6 +119,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(const char* name = API(host->handle, info[0]->Int32Value());\
     if (name)\
@@ -132,6 +138,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value(),\
                      info[2]->NumberValue(), info[3]->NumberValue());)\
@@ -146,6 +153,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->NumberValue());)\
 }
@@ -159,6 +167,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value()));)\
 }
@@ -185,6 +194,7 @@ static NAN_METHOD(NAME) {\
     for (size_t i = 0; i < ja->Length(); i++) pja[i] = ja->Get(i)->Int32Value();\
     for (size_t i = 0; i < ar->Length(); i++) par[i] = ar->Get(i)->NumberValue();\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), count, pja, par);)\
     \
@@ -201,6 +211,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     try{\
         int row = info[0]->Int32Value();\
@@ -236,6 +247,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle);)\
 }
@@ -256,6 +268,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
     count--;\
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, count, idx);)\
     free(idx);\
@@ -270,6 +283,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0])));)\
 }
@@ -283,6 +297,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(API(host->handle, info[0]->Int32Value(), info[1]->Int32Value());)\
 }
@@ -296,6 +311,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, info[0]->Int32Value(), V8TOCSTRING(info[1])));)\
 }
@@ -309,6 +325,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!host->handle, "object deleted");\
     V8CHECK(host->thread.load(), "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{host->memstats_}; \
     TermHookGuard hookguard{host->info_}; \
     GLP_CATCH_RET(info.GetReturnValue().Set(API(host->handle, V8TOCSTRING(info[0]), info[1]->Int32Value()));)\
 }
@@ -319,6 +336,7 @@ static NAN_METHOD(NAME) {\
     V8CHECK(!obj->handle, "object already deleted");\
     V8CHECK(obj->thread, "an async operation is inprogress")\
     \
+    MemStatsGuard mguard{obj->memstats_}; \
     TermHookGuard hookguard{obj->info_}; \
     GLP_CATCH_RET(API(obj->handle);)\
     obj->handle = NULL;\
@@ -372,7 +390,8 @@ static NAN_METHOD(NAME) {\
     Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());\
     NAME##Worker *worker = new NAME##Worker(callback, lp, V8TOCSTRING(info[0]));\
     lp->thread = true;\
-    EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_); \
+    EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_); \
+    MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_); \
     Nan::AsyncQueueWorker(decorated);\
 }\
 
@@ -417,7 +436,8 @@ static NAN_METHOD(NAME) {\
     Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());\
     NAME##Worker *worker = new NAME##Worker(callback, lp, info[0]->Int32Value(), V8TOCSTRING(info[1]));\
     lp->thread = true;\
-    EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_); \
+    EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_); \
+    MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_); \
     Nan::AsyncQueueWorker(decorated);\
 }\
 
@@ -453,7 +473,8 @@ static NAN_METHOD(NAME) {\
     Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());\
     NAME##Worker *worker = new NAME##Worker(callback, lp);\
     lp->thread = true;\
-    EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_); \
+    EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_); \
+    MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_); \
     Nan::AsyncQueueWorker(decorated);\
 }\
 

--- a/src/glpk/env/alloc.c
+++ b/src/glpk/env/alloc.c
@@ -47,9 +47,7 @@
 #ifdef HAVE_ENV
 static void *dma(const char *func, void *ptr, size_t size)
 {
-#ifndef GLOBAL_MEM_STATS
       ENV *env = get_env_ptr();
-#endif
       MBD *mbd;
       if (ptr == NULL)
       {  /* new memory block will be allocated */
@@ -99,8 +97,8 @@ static void *dma(const char *func, void *ptr, size_t size)
       /* setup the block descriptor */
       mbd->size = size;
       mbd->self = mbd;
-      mbd->prev = NULL;
 #ifndef GLOBAL_MEM_STATS
+      mbd->prev = NULL;
       mbd->next = env->mem_ptr;
       /* add the block to the beginning of the linked list */
       if (mbd->next != NULL)

--- a/src/glpk/env/env.c
+++ b/src/glpk/env/env.c
@@ -111,6 +111,7 @@ int glp_init_env(void)
       env->mem_count = env->mem_cpeak = 0;
       env->mem_total = env->mem_tpeak = 0;
 #endif
+      env->memstats = NULL;
       env->h_odbc = env->h_mysql = NULL;
       /* save pointer to the environment block */
       tls_set_ptr(env);
@@ -167,6 +168,18 @@ ENV *get_env_ptr(void)
 }
 #endif
 
+#ifdef HAVE_ENV
+glp_memstats* glp_set_memstats(glp_memstats* new_stats)
+{
+    ENV *env = get_env_ptr();
+    glp_memstats* prior = env->memstats;
+    env->memstats = new_stats;
+    return prior;
+}
+#endif
+
+
+#ifdef HAVE_ENV
 /***********************************************************************
 *  NAME
 *
@@ -182,14 +195,13 @@ ENV *get_env_ptr(void)
 *  character string, which specifies the version of the GLPK library in
 *  the form "X.Y", where X is the major version number, and Y is the
 *  minor version number, for example, "4.16". */
-
-#ifdef HAVE_ENV
 const char *glp_version(void)
 {     ENV *env = get_env_ptr();
       return env->version;
 }
 #endif
 
+#ifdef HAVE_ENV
 /***********************************************************************
 *  NAME
 *
@@ -218,8 +230,6 @@ const char *glp_version(void)
 *
 *  0 - termination successful;
 *  1 - environment is inactive (was not initialized). */
-
-#ifdef HAVE_ENV
 int glp_free_env(void)
 {
       ENV *env = (ENV*) tls_get_ptr();

--- a/src/glpk/env/glpenv.h
+++ b/src/glpk/env/glpenv.h
@@ -221,28 +221,28 @@ struct MBD
 #endif
 };
 
-inline __attribute__((always_inline)) size_t _add_mem_total_func(ENV* env, size_t x) {
+static inline __attribute__((always_inline)) size_t _add_mem_total_func(ENV* env, size_t x) {
     if(env && env->memstats) {
         env->memstats->problem_mem_total += x;
     }
     return _add_mem_total(x);
 }
 
-inline __attribute__((always_inline)) size_t _add_mem_count_func(ENV* env, size_t x) {
+static inline __attribute__((always_inline)) size_t _add_mem_count_func(ENV* env, size_t x) {
     if(env && env->memstats) {
         env->memstats->problem_mem_count += x;
     }
     return _add_mem_count(x);
 }
 
-inline __attribute__((always_inline)) void _set_mem_tpeak_func(ENV* env, size_t x) {
+static inline __attribute__((always_inline)) void _set_mem_tpeak_func(ENV* env, size_t x) {
     if(env && env->memstats && x > env->memstats->problem_mem_tpeak) {
         env->memstats->problem_mem_tpeak = x;
     }
     _set_mem_tpeak(x);
 }
 
-inline __attribute__((always_inline)) void _set_mem_cpeak_func(ENV* env, size_t x) {
+static inline __attribute__((always_inline)) void _set_mem_cpeak_func(ENV* env, size_t x) {
     if(env && env->memstats && x > env->memstats->problem_mem_cpeak) {
         env->memstats->problem_mem_cpeak = x;
     }

--- a/src/glpk/env/glpenv.h
+++ b/src/glpk/env/glpenv.h
@@ -25,6 +25,8 @@
 #define ENV_H
 
 #include "stdc.h"
+#include "memstats.h"
+#include <execinfo.h>
 
 #ifdef HAVE_ENV
 typedef struct ENV ENV;
@@ -70,31 +72,31 @@ extern volatile size_t mem_tpeak;
 
 #ifdef HAVE_ATOMIC
 
-#define add_mem_limit(x) __atomic_add_fetch(&mem_limit, x, __ATOMIC_CONSUME)
-#define add_mem_count(x) __atomic_add_fetch(&mem_count, x, __ATOMIC_CONSUME)
-#define add_mem_cpeak(x) __atomic_add_fetch(&mem_cpeak, x, __ATOMIC_CONSUME)
-#define add_mem_total(x) __atomic_add_fetch(&mem_total, x, __ATOMIC_CONSUME)
-#define add_mem_tpeak(x) __atomic_add_fetch(&mem_tpeak, x, __ATOMIC_CONSUME)
+#define _add_mem_limit(x) __atomic_add_fetch(&mem_limit, x, __ATOMIC_CONSUME)
+#define _add_mem_count(x) __atomic_add_fetch(&mem_count, x, __ATOMIC_CONSUME)
+#define _add_mem_cpeak(x) __atomic_add_fetch(&mem_cpeak, x, __ATOMIC_CONSUME)
+#define _add_mem_total(x) __atomic_add_fetch(&mem_total, x, __ATOMIC_CONSUME)
+#define _add_mem_tpeak(x) __atomic_add_fetch(&mem_tpeak, x, __ATOMIC_CONSUME)
 
 #define _cmpxchg(DEST, CMP, SRC) __atomic_compare_exchange_n(DEST, &CMP, SRC, 0, __ATOMIC_RELEASE, __ATOMIC_RELAXED)
 
 #elif HAVE_SYNC // ifdef HAVE_ATOMIC
 
-#define add_mem_limit(x) __sync_add_and_fetch(&mem_limit, x)
-#define add_mem_count(x) __sync_add_and_fetch(&mem_count, x)
-#define add_mem_cpeak(x) __sync_add_and_fetch(&mem_cpeak, x)
-#define add_mem_total(x) __sync_add_and_fetch(&mem_total, x)
-#define add_mem_tpeak(x) __sync_add_and_fetch(&mem_tpeak, x)
+#define _add_mem_limit(x) __sync_add_and_fetch(&mem_limit, x)
+#define _add_mem_count(x) __sync_add_and_fetch(&mem_count, x)
+#define _add_mem_cpeak(x) __sync_add_and_fetch(&mem_cpeak, x)
+#define _add_mem_total(x) __sync_add_and_fetch(&mem_total, x)
+#define _add_mem_tpeak(x) __sync_add_and_fetch(&mem_tpeak, x)
 
 #define _cmpxchg(DEST, CMP, SRC) __sync_val_compare_and_swap(DEST, CMP, SRC)
 
 #else  // ifdef HAVE_ATOMIC elif HAVE_SYNC
 
-#define add_mem_limit(x) (mem_limit += x)
-#define add_mem_count(x) (mem_count += x)
-#define add_mem_cpeak(x) (mem_cpeak += x)
-#define add_mem_total(x) (mem_total += x)
-#define add_mem_tpeak(x) (mem_tpeak += x)
+#define _add_mem_limit(x) (mem_limit += x)
+#define _add_mem_count(x) (mem_count += x)
+#define _add_mem_cpeak(x) (mem_cpeak += x)
+#define _add_mem_total(x) (mem_total += x)
+#define _add_mem_tpeak(x) (mem_tpeak += x)
 
 
 #endif // ifdef HAVE_ATOMIC elif HAVE_SYNC
@@ -115,31 +117,34 @@ extern volatile size_t mem_tpeak;
 
 #else // #ifdef GLOBAL_MEM_STATS 
 
-#define add_mem_limit(x) (env->mem_limit += x)
-#define add_mem_count(x) (env->mem_count += x)
-#define add_mem_cpeak(x) (env->mem_cpeak += x)
-#define add_mem_total(x) (env->mem_total += x)
-#define add_mem_tpeak(x) (env->mem_tpeak += x)
+#define _add_mem_limit(x) (env->mem_limit += x)
+#define _add_mem_count(x) (env->mem_count += x)
+#define _add_mem_cpeak(x) (env->mem_cpeak += x)
+#define _add_mem_total(x) (env->mem_total += x)
+#define _add_mem_tpeak(x) (env->mem_tpeak += x)
 
 #define _set_peak(VALUE, PEAK)                                \
     do {                                                      \
         if (VALUE > env->mem_##PEAK) env->mem_##PEAK = VALUE; \
     } while (0)
 
-#define set_mem_limit(VALUE) (env->mem_limit = VALUE)
+#define _set_mem_limit(VALUE) (env->mem_limit = VALUE)
 
 #endif // #ifdef GLOBAL_MEM_STATS
 
-#define set_mem_tpeak(TOTAL) _set_peak(TOTAL, tpeak)
-#define set_mem_cpeak(COUNT) _set_peak(COUNT, cpeak)
+#define _set_mem_tpeak(TOTAL) _set_peak(TOTAL, tpeak)
+#define _set_mem_cpeak(COUNT) _set_peak(COUNT, cpeak)
 
-#define get_mem_limit() add_mem_limit(0)
-#define get_mem_count() add_mem_count(0)
-#define get_mem_cpeak() add_mem_cpeak(0)
-#define get_mem_total() add_mem_total(0)
-#define get_mem_tpeak() add_mem_tpeak(0)
+#define get_mem_limit() _add_mem_limit(0)
+#define get_mem_count() _add_mem_count(0)
+#define get_mem_cpeak() _add_mem_cpeak(0)
+#define get_mem_total() _add_mem_total(0)
+#define get_mem_tpeak() _add_mem_tpeak(0)
 
-
+#define set_mem_tpeak(TOTAL) _set_mem_tpeak_func(env, TOTAL);
+#define set_mem_cpeak(COUNT) _set_mem_cpeak_func(env, COUNT);
+#define add_mem_count(x) _add_mem_count_func(env, x);
+#define add_mem_total(x) _add_mem_total_func(env, x);
 
 struct ENV
 {     /* GLPK environment block */
@@ -193,6 +198,7 @@ struct ENV
       size_t mem_tpeak;
       /* peak value of mem_total */
 #endif
+      glp_memstats* memstats;
       /*--------------------------------------------------------------*/
       /* dynamic linking support (optional) */
       void *h_odbc;
@@ -207,11 +213,94 @@ struct MBD
       /* size of block, in bytes, including descriptor */
       MBD *self;
       /* pointer to this descriptor to check its validity */
+#ifndef GLOBAL_MEM_STATS
       MBD *prev;
       /* pointer to previous memory block descriptor */
       MBD *next;
       /* pointer to next memory block descriptor */
+#endif
 };
+
+inline __attribute__((always_inline)) void print_trace (void)
+{
+  size_t size = 20;
+  void *array[size];
+  char **strings;
+  size_t i;
+
+  size = backtrace(array, size);
+  strings = backtrace_symbols(array, size);
+
+  fprintf(stderr, "Obtained %zd stack frames.\n", size);
+
+  for (i = 0; i < size; i++)
+     printf("%s\n", strings[i]);
+
+  free(strings);
+}
+
+
+inline __attribute__((always_inline)) size_t _add_mem_total_func(ENV* env, size_t x) {
+    if(!env) {
+        fprintf(stderr, "Env not set:\n");
+        print_trace();
+    }
+    if(env && !env->memstats) {
+        fprintf(stderr, "memstats not set:\n");
+        print_trace();
+    }
+    if(env && env->memstats) {
+        env->memstats->problem_mem_total += x;
+    }
+    return _add_mem_total(x);
+}
+
+inline __attribute__((always_inline)) size_t _add_mem_count_func(ENV* env, size_t x) {
+    if(!env) {
+        fprintf(stderr, "Env not set:\n");
+        print_trace();
+    }
+    if(env && !env->memstats) {
+        fprintf(stderr, "memstats not set:\n");
+        print_trace();
+    }
+    if(env && env->memstats) {
+        env->memstats->problem_mem_count += x;
+    }
+    return _add_mem_count(x);
+}
+
+inline __attribute__((always_inline)) void _set_mem_tpeak_func(ENV* env, size_t x) {
+    if(!env) {
+        fprintf(stderr, "Env not set:\n");
+        print_trace();
+    }
+    if(env && !env->memstats) {
+        fprintf(stderr, "memstats not set:\n");
+        print_trace();
+    }
+    if(env && env->memstats && x > env->memstats->problem_mem_tpeak) {
+        env->memstats->problem_mem_tpeak = x;
+    }
+    _set_mem_tpeak(x);
+}
+
+inline __attribute__((always_inline)) void _set_mem_cpeak_func(ENV* env, size_t x) {
+    if(!env) {
+        fprintf(stderr, "Env not set:\n");
+        print_trace();
+    }
+    if(env && !env->memstats) {
+        fprintf(stderr, "memstats not set:\n");
+        print_trace();
+    }
+    if(env && env->memstats && x > env->memstats->problem_mem_cpeak) {
+        env->memstats->problem_mem_cpeak = x;
+    }
+    _set_mem_cpeak(x);
+}
+
+
 #endif
 
 #ifdef HAVE_ENV
@@ -245,11 +334,11 @@ int glp_term_out(int flag);
 
 #ifdef HAVE_ENV
 void glp_term_hook(int (*func)(void *info, const char *s), void *info);
+
 #else
 void glp_term_hook(void (*func)(const char *s));
 #endif
 /* install hook to intercept terminal output */
-
 int glp_open_tee(const char *fname);
 /* start copying terminal output to text file */
 

--- a/src/glpk/env/glpenv.h
+++ b/src/glpk/env/glpenv.h
@@ -221,34 +221,7 @@ struct MBD
 #endif
 };
 
-inline __attribute__((always_inline)) void print_trace (void)
-{
-  size_t size = 20;
-  void *array[size];
-  char **strings;
-  size_t i;
-
-  size = backtrace(array, size);
-  strings = backtrace_symbols(array, size);
-
-  fprintf(stderr, "Obtained %zd stack frames.\n", size);
-
-  for (i = 0; i < size; i++)
-     printf("%s\n", strings[i]);
-
-  free(strings);
-}
-
-
 inline __attribute__((always_inline)) size_t _add_mem_total_func(ENV* env, size_t x) {
-    if(!env) {
-        fprintf(stderr, "Env not set:\n");
-        print_trace();
-    }
-    if(env && !env->memstats) {
-        fprintf(stderr, "memstats not set:\n");
-        print_trace();
-    }
     if(env && env->memstats) {
         env->memstats->problem_mem_total += x;
     }
@@ -256,14 +229,6 @@ inline __attribute__((always_inline)) size_t _add_mem_total_func(ENV* env, size_
 }
 
 inline __attribute__((always_inline)) size_t _add_mem_count_func(ENV* env, size_t x) {
-    if(!env) {
-        fprintf(stderr, "Env not set:\n");
-        print_trace();
-    }
-    if(env && !env->memstats) {
-        fprintf(stderr, "memstats not set:\n");
-        print_trace();
-    }
     if(env && env->memstats) {
         env->memstats->problem_mem_count += x;
     }
@@ -271,14 +236,6 @@ inline __attribute__((always_inline)) size_t _add_mem_count_func(ENV* env, size_
 }
 
 inline __attribute__((always_inline)) void _set_mem_tpeak_func(ENV* env, size_t x) {
-    if(!env) {
-        fprintf(stderr, "Env not set:\n");
-        print_trace();
-    }
-    if(env && !env->memstats) {
-        fprintf(stderr, "memstats not set:\n");
-        print_trace();
-    }
     if(env && env->memstats && x > env->memstats->problem_mem_tpeak) {
         env->memstats->problem_mem_tpeak = x;
     }
@@ -286,14 +243,6 @@ inline __attribute__((always_inline)) void _set_mem_tpeak_func(ENV* env, size_t 
 }
 
 inline __attribute__((always_inline)) void _set_mem_cpeak_func(ENV* env, size_t x) {
-    if(!env) {
-        fprintf(stderr, "Env not set:\n");
-        print_trace();
-    }
-    if(env && !env->memstats) {
-        fprintf(stderr, "memstats not set:\n");
-        print_trace();
-    }
     if(env && env->memstats && x > env->memstats->problem_mem_cpeak) {
         env->memstats->problem_mem_cpeak = x;
     }

--- a/src/glpk/env/memstats.h
+++ b/src/glpk/env/memstats.h
@@ -1,0 +1,26 @@
+#pragma once
+#ifndef GLPK_ENV_MEMSTATS_H
+#define GLPK_ENV_MEMSTATS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct MEMSTATS {
+    size_t problem_mem_count;
+    size_t problem_mem_cpeak;
+    size_t problem_mem_total;
+    size_t problem_mem_tpeak;
+} glp_memstats;
+
+#ifdef HAVE_ENV
+glp_memstats* glp_set_memstats(glp_memstats* new_stats);
+// set the memstats on the current env
+#endif
+
+#ifdef __cplusplus
+}
+#endif 
+
+#endif

--- a/src/glpk/glpk.h
+++ b/src/glpk/glpk.h
@@ -30,6 +30,7 @@
 #include <stddef.h>
 
 #include <cemitter.h>
+#include "env/memstats.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -249,9 +249,8 @@ namespace NodeGLPK {
             Mathprog* host = ObjectWrap::Unwrap<Mathprog>(info.Holder());
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread.load(), "an async operation is inprogress");
-            
-            TermHookGuard hookguard{host->info_};
-            MemStatsGuard mguard{host->memstats_};
+           
+            GLP_CREATE_HOOK_GUARDS(host); 
             GLP_CATCH_RET(
                 if ((info.Length() == 1) && (!info[0]->IsString()))
                     info.GetReturnValue().Set(glp_mpl_generate(host->handle, V8TOCSTRING(info[0])));
@@ -316,8 +315,7 @@ namespace NodeGLPK {
             Problem* lp = ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             
-            TermHookGuard hookguard{mp->info_};
-            MemStatsGuard mguard{mp->memstats_};
+            GLP_CREATE_HOOK_GUARDS(mp); 
             GLP_CATCH_RET(glp_mpl_build_prob(mp->handle, lp->handle);)
         }
 
@@ -380,8 +378,7 @@ namespace NodeGLPK {
             Problem* lp = ObjectWrap::Unwrap<Problem>(info[0]->ToObject());
             V8CHECK(!lp || !lp->handle, "invalid problem");
             
-            TermHookGuard hookguard{mp->info_};
-            MemStatsGuard mguard{mp->memstats_};
+            GLP_CREATE_HOOK_GUARDS(mp); 
             GLP_CATCH_RET(info.GetReturnValue().Set(glp_mpl_postsolve(mp->handle, lp->handle, info[1]->Int32Value()));)
         }
         
@@ -402,8 +399,7 @@ namespace NodeGLPK {
             V8CHECK(!mp->handle, "object deleted");
             V8CHECK(mp->thread.load(), "an async operation is inprogress");
 
-            TermHookGuard hookguard{mp->info_};
-            MemStatsGuard mguard{mp->memstats_};
+            GLP_CREATE_HOOK_GUARDS(mp); 
 
             char * msg = glp_mpl_getlasterror(mp->handle);
             if (msg)

--- a/src/mathprog.hpp
+++ b/src/mathprog.hpp
@@ -90,7 +90,7 @@ namespace NodeGLPK {
             V8CHECK(info.Length() != 0, "Wrong number of arguments");
 
             Mathprog* mp = ObjectWrap::Unwrap<Mathprog>(info.Holder());
-            V8CHECK(!mp->handle, "object deleted");
+            V8CHECK(!mp->memstats_, "object deleted");
 
             Local<v8::Object> ret = Nan::New<v8::Object>();
             ret->Set(Nan::New<v8::String>("count").ToLocalChecked(), Nan::New<v8::Number>(mp->memstats_->problem_mem_count));

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -305,8 +305,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{lp->info_};
-            MemStatsGuard mguard{lp->memstats_}; 
+            GLP_CREATE_HOOK_GUARDS(lp); 
             GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(), pia, pja, par);)
 
             
@@ -324,8 +323,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{lp->info_};
-                      MemStatsGuard mguard{lp->memstats_}; 
+                      GLP_CREATE_HOOK_GUARDS(lp); 
                       glp_init_smcp(&scmp);
                       if (info.Length() == 1)
                           if (!SmcpInit(&scmp, info[0])) return;
@@ -340,8 +338,7 @@ namespace NodeGLPK {
             SimplexWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
 
-                TermHookGuard hookguard{lp->info_};
-                MemStatsGuard mguard{lp->memstats_}; 
+                GLP_CREATE_HOOK_GUARDS(lp); 
                 glp_init_smcp(&smcp);
                 lp->emitter_->emit("initialized", "Complete");
             }
@@ -392,8 +389,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{lp->info_};
-                      MemStatsGuard mguard{lp->memstats_}; 
+                      GLP_CREATE_HOOK_GUARDS(lp); 
                       glp_init_smcp(&scmp);
                       if (info.Length() == 1) {
                           if (info[0]->IsObject())
@@ -409,8 +405,7 @@ namespace NodeGLPK {
         public:
             ExactWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
-                TermHookGuard hookguard{lp->info_};
-                MemStatsGuard mguard{lp->memstats_}; 
+                GLP_CREATE_HOOK_GUARDS(lp); 
                 glp_init_smcp(&smcp);
             }
             void WorkComplete() {
@@ -484,8 +479,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{lp->info_};
-                      MemStatsGuard mguard{lp->memstats_}; 
+                      GLP_CREATE_HOOK_GUARDS(lp); 
                       glp_init_iptcp(&iptcp);
                       if (info.Length() == 1)
                          if (!IptcpInit(&iptcp, info[0])) return;
@@ -498,8 +492,7 @@ namespace NodeGLPK {
         public:
             InteriorWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
-                TermHookGuard hookguard{lp->info_};
-                MemStatsGuard mguard{lp->memstats_}; 
+                GLP_CREATE_HOOK_GUARDS(lp); 
                 glp_init_iptcp(&iptcp);
             }
             void WorkComplete() {
@@ -579,8 +572,7 @@ namespace NodeGLPK {
                 V8CHECK(!lp->handle, "object deleted");
                 V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                TermHookGuard hookguard{lp->info_};
-                MemStatsGuard mguard{lp->memstats_}; 
+                GLP_CREATE_HOOK_GUARDS(lp); 
                 glp_init_mpscp(&mpscp);
                 if (info.Length() == 1)
                     if (!MpscpInit(&mpscp, info[0])) return;
@@ -596,8 +588,7 @@ namespace NodeGLPK {
         public:
             ReadMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
             : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
-                TermHookGuard hookguard{lp->info_};
-                MemStatsGuard mguard{lp->memstats_}; 
+                GLP_CREATE_HOOK_GUARDS(lp); 
                 glp_init_mpscp(&mpscp);
             }
             
@@ -660,8 +651,7 @@ namespace NodeGLPK {
               V8CHECK(!lp->handle, "object deleted");
               V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-              TermHookGuard hookguard{lp->info_};
-              MemStatsGuard mguard{lp->memstats_}; 
+              GLP_CREATE_HOOK_GUARDS(lp); 
               glp_init_mpscp(&mpscp);
               if (info.Length() == 1)
                 if (!MpscpInit(&mpscp, info[0])) return;
@@ -675,8 +665,7 @@ namespace NodeGLPK {
         public:
             WriteMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
             : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
-                TermHookGuard hookguard{lp->info_};
-                MemStatsGuard mguard{lp->memstats_}; 
+                GLP_CREATE_HOOK_GUARDS(lp); 
                 glp_init_mpscp(&mpscp);
             }
             
@@ -850,8 +839,7 @@ namespace NodeGLPK {
                       V8CHECK(!lp->handle, "object deleted");
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
-                      TermHookGuard hookguard{lp->info_};
-                      MemStatsGuard mguard{lp->memstats_}; 
+                      GLP_CREATE_HOOK_GUARDS(lp); 
                       glp_init_iocp(&iocp);
                       if (info.Length() == 1) {
                           if (IocpInit(lp, &iocp, info[0])) {
@@ -874,8 +862,7 @@ namespace NodeGLPK {
                  lp(lp),
                  parm(),
                  ctx() {
-               TermHookGuard hookguard{lp->info_};
-               MemStatsGuard mguard{lp->memstats_}; 
+               GLP_CREATE_HOOK_GUARDS(lp); 
                glp_init_iocp(&parm);
                glp_init_mip_ctx(&ctx);
                ctx.parm = &parm;
@@ -997,8 +984,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{lp->info_};
-            MemStatsGuard mguard{lp->memstats_}; 
+            GLP_CREATE_HOOK_GUARDS(lp); 
             info.GetReturnValue().Set(glp_read_lp(lp->handle, NULL, V8TOCSTRING(info[0])));
         }
         
@@ -1054,8 +1040,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{lp->info_};
-            MemStatsGuard mguard{lp->memstats_}; 
+            GLP_CREATE_HOOK_GUARDS(lp); 
             GLP_CATCH_RET(info.GetReturnValue().Set(glp_write_lp(lp->handle, NULL, V8TOCSTRING(info[0])));)
         }
         
@@ -1113,8 +1098,7 @@ namespace NodeGLPK {
             double ae_max, re_max;
             int ae_ind, re_ind;
 
-            TermHookGuard hookguard{lp->info_};
-            MemStatsGuard mguard{lp->memstats_}; 
+            GLP_CREATE_HOOK_GUARDS(lp); 
             GLP_CATCH_RET(glp_check_kkt(lp->handle, info[0]->Int32Value(), info[1]->Int32Value(), &ae_max, &ae_ind, &re_max, &re_ind);)
             
             Nan::Callback* cb = new Nan::Callback(Local<Function>::Cast(info[2]));
@@ -1141,8 +1125,7 @@ namespace NodeGLPK {
             uint32_t count = 0;
             int* plist = NULL;
             int ret = 0;
-            TermHookGuard hookguard{lp->info_};
-            MemStatsGuard mguard{lp->memstats_}; 
+            GLP_CREATE_HOOK_GUARDS(lp); 
             GLP_CATCH(
                 if (info[0]->IsInt32Array()) {
                     Local<Int32Array> list = Local<Int32Array>::Cast(info[0]);
@@ -1231,8 +1214,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{lp->info_};
-            MemStatsGuard mguard{lp->memstats_}; 
+            GLP_CREATE_HOOK_GUARDS(lp); 
             GLP_CATCH_RET(
                 glp_bfcp bfcp;
                 glp_get_bfcp(lp->handle, &bfcp);
@@ -1257,8 +1239,7 @@ namespace NodeGLPK {
             V8CHECK(!lp->handle, "object deleted");
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
-            TermHookGuard hookguard{lp->info_};
-            MemStatsGuard mguard{lp->memstats_}; 
+            GLP_CREATE_HOOK_GUARDS(lp); 
             GLP_CATCH_RET(
                       glp_bfcp bfcp;
                       glp_get_bfcp(lp->handle, &bfcp);

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <mutex>
 
-
 #include <node.h>
 #include <node_object_wrap.h>
 #include <stdlib.h>
@@ -163,6 +162,7 @@ namespace NodeGLPK {
             Nan::SetPrototypeMethod(tpl, "getRowBind", GetRowBind);
             Nan::SetPrototypeMethod(tpl, "getColBind", GetColBind);
             Nan::SetPrototypeMethod(tpl, "warmUp", WarmUp);
+            Nan::SetPrototypeMethod(tpl, "memStats", MemStats);
             
             constructor.Reset(tpl);
             exports->Set(Nan::New<String>("Problem").ToLocalChecked(), tpl->GetFunction());
@@ -230,14 +230,21 @@ namespace NodeGLPK {
        explicit Problem()
            : node::ObjectWrap(),
              emitter_(std::make_shared<NodeEvent::EventEmitter>()),
+             memstats_(std::make_shared<glp_memstats>()),
              info_{std::make_shared<HookInfo>(emitter_, nullptr, nullptr)} {
+           
            TermHookGuard hookguard{info_};
+           MemStatsGuard mguard{memstats_}; 
            handle = glp_create_prob();
            thread = false;
         }
 
         ~Problem(){
-            if (handle) glp_delete_prob(handle);
+            if (handle) {
+                TermHookGuard hookguard{info_};
+                MemStatsGuard mguard{memstats_}; 
+                glp_delete_prob(handle);
+            }
         }
        
         static NAN_METHOD(New) {
@@ -262,6 +269,21 @@ namespace NodeGLPK {
             lp->emitter_->on(s, callback);
         }
 
+        static NAN_METHOD(MemStats) {
+            V8CHECK(info.Length() != 0, "Wrong number of arguments");
+
+            Problem* lp = ObjectWrap::Unwrap<Problem>(info.Holder());
+            V8CHECK(!lp->handle, "object deleted");
+
+            Local<v8::Object> ret = Nan::New<v8::Object>();
+            ret->Set(Nan::New<v8::String>("count").ToLocalChecked(), Nan::New<v8::Number>(lp->memstats_->problem_mem_count));
+            ret->Set(Nan::New<v8::String>("cpeak").ToLocalChecked(), Nan::New<v8::Number>(lp->memstats_->problem_mem_cpeak));
+            ret->Set(Nan::New<v8::String>("total").ToLocalChecked(), Nan::New<v8::Number>(lp->memstats_->problem_mem_total));
+            ret->Set(Nan::New<v8::String>("tpeak").ToLocalChecked(), Nan::New<v8::Number>(lp->memstats_->problem_mem_tpeak));
+
+            info.GetReturnValue().Set(ret);
+        }
+
         static NAN_METHOD(LoadMatrix) {
             V8CHECK(info.Length() != 4, "Wrong number of arguments");
             V8CHECK(!info[0]->IsInt32() || !info[1]->IsInt32Array()
@@ -284,6 +306,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
             TermHookGuard hookguard{lp->info_};
+            MemStatsGuard mguard{lp->memstats_}; 
             GLP_CATCH(glp_load_matrix(lp->handle, info[0]->Int32Value(), pia, pja, par);)
 
             
@@ -302,6 +325,7 @@ namespace NodeGLPK {
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
                       TermHookGuard hookguard{lp->info_};
+                      MemStatsGuard mguard{lp->memstats_}; 
                       glp_init_smcp(&scmp);
                       if (info.Length() == 1)
                           if (!SmcpInit(&scmp, info[0])) return;
@@ -317,6 +341,7 @@ namespace NodeGLPK {
             : Nan::AsyncWorker(callback), lp(lp){
 
                 TermHookGuard hookguard{lp->info_};
+                MemStatsGuard mguard{lp->memstats_}; 
                 glp_init_smcp(&smcp);
                 lp->emitter_->emit("initialized", "Complete");
             }
@@ -353,7 +378,8 @@ namespace NodeGLPK {
                 return;
             }
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -367,6 +393,7 @@ namespace NodeGLPK {
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
                       TermHookGuard hookguard{lp->info_};
+                      MemStatsGuard mguard{lp->memstats_}; 
                       glp_init_smcp(&scmp);
                       if (info.Length() == 1) {
                           if (info[0]->IsObject())
@@ -383,6 +410,7 @@ namespace NodeGLPK {
             ExactWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
                 TermHookGuard hookguard{lp->info_};
+                MemStatsGuard mguard{lp->memstats_}; 
                 glp_init_smcp(&smcp);
             }
             void WorkComplete() {
@@ -418,7 +446,8 @@ namespace NodeGLPK {
                 return;
             }
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -456,6 +485,7 @@ namespace NodeGLPK {
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
                       TermHookGuard hookguard{lp->info_};
+                      MemStatsGuard mguard{lp->memstats_}; 
                       glp_init_iptcp(&iptcp);
                       if (info.Length() == 1)
                          if (!IptcpInit(&iptcp, info[0])) return;
@@ -469,6 +499,7 @@ namespace NodeGLPK {
             InteriorWorker(Nan::Callback *callback, Problem *lp)
             : Nan::AsyncWorker(callback), lp(lp){
                 TermHookGuard hookguard{lp->info_};
+                MemStatsGuard mguard{lp->memstats_}; 
                 glp_init_iptcp(&iptcp);
             }
             void WorkComplete() {
@@ -504,7 +535,8 @@ namespace NodeGLPK {
                 return;
             }
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -548,6 +580,7 @@ namespace NodeGLPK {
                 V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
                 TermHookGuard hookguard{lp->info_};
+                MemStatsGuard mguard{lp->memstats_}; 
                 glp_init_mpscp(&mpscp);
                 if (info.Length() == 1)
                     if (!MpscpInit(&mpscp, info[0])) return;
@@ -564,6 +597,7 @@ namespace NodeGLPK {
             ReadMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
             : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
                 TermHookGuard hookguard{lp->info_};
+                MemStatsGuard mguard{lp->memstats_}; 
                 glp_init_mpscp(&mpscp);
             }
             
@@ -609,7 +643,8 @@ namespace NodeGLPK {
                 return;
             }
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -626,6 +661,7 @@ namespace NodeGLPK {
               V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
               TermHookGuard hookguard{lp->info_};
+              MemStatsGuard mguard{lp->memstats_}; 
               glp_init_mpscp(&mpscp);
               if (info.Length() == 1)
                 if (!MpscpInit(&mpscp, info[0])) return;
@@ -640,6 +676,7 @@ namespace NodeGLPK {
             WriteMpsWorker(Nan::Callback *callback, Problem *lp, int fmt, std::string file)
             : Nan::AsyncWorker(callback), fmt(fmt), lp(lp), file(file){
                 TermHookGuard hookguard{lp->info_};
+                MemStatsGuard mguard{lp->memstats_}; 
                 glp_init_mpscp(&mpscp);
             }
             
@@ -685,25 +722,33 @@ namespace NodeGLPK {
                 return;
             }
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
-        
+ 
+        struct IocpCallbackInfo {
+            IocpCallbackInfo(Nan::Callback* cb, std::shared_ptr<glp_memstats> ms) : callback(cb), memstats(ms) {}
+            ~IocpCallbackInfo() noexcept { delete callback; }
+            Nan::Callback* callback;
+            std::shared_ptr<glp_memstats> memstats;
+        };
+       
         
         
         static void IocpCallback(glp_tree *T, void *info){
-            Nan::Callback* cb = (Nan::Callback*)info;
+            IocpCallbackInfo* cbinfo = static_cast<IocpCallbackInfo*>(info);
             const unsigned argc = 1;
-            Local<Value> t = Tree::Instantiate(T);
+            Local<Value> t = Tree::Instantiate(T, cbinfo->memstats);
             Local<Value> argv[argc] = {Nan::New<Value>(t)};
-            cb->Call(argc, argv);
+            cbinfo->callback->Call(argc, argv);
             Tree* host = ObjectWrap::Unwrap<Tree>(t->ToObject());
             host->thread = true;
             host->handle = NULL;
         };
         
         
-        static bool IocpInit(glp_iocp *iocp, Local<Value> value){
+        static bool IocpInit(Problem* lp, glp_iocp *iocp, Local<Value> value){
             if (value->IsObject()){
                 Local<Object> obj = value->ToObject();
                 Local<Array> props = obj->GetPropertyNames();
@@ -782,7 +827,7 @@ namespace NodeGLPK {
                     } else if (keystr == "cbFunc"){
                         V8CHECKBOOL(!val->IsFunction(), "cbFunc: should be a function");
                         iocp->cb_func = IocpCallback;
-                        iocp->cb_info = new Nan::Callback(Local<Function>::Cast(val));
+                        iocp->cb_info = new IocpCallbackInfo(new Nan::Callback(Local<Function>::Cast(val)), lp->memstats_);
                     } else if (keystr == "cbReasons"){
                         V8CHECKBOOL(!val->IsInt32(), "cbReason: should be int32");
                         iocp->cb_reasons = val->Int32Value();
@@ -806,13 +851,14 @@ namespace NodeGLPK {
                       V8CHECK(lp->thread.load(), "an async operation is inprogress");
 
                       TermHookGuard hookguard{lp->info_};
+                      MemStatsGuard mguard{lp->memstats_}; 
                       glp_init_iocp(&iocp);
-                      if (info.Length() == 1)
-                          if (!IocpInit(&iocp, info[0])) return;
-                      
-                          
-                      glp_intopt(lp->handle, &iocp);
-                      if (iocp.cb_info) delete (Nan::Callback*)iocp.cb_info;
+                      if (info.Length() == 1) {
+                          if (IocpInit(lp, &iocp, info[0])) {
+                              glp_intopt(lp->handle, &iocp);
+                          }
+                      }
+                      if (iocp.cb_info) delete static_cast<IocpCallbackInfo*>(iocp.cb_info);
                       if (iocp.save_sol) delete[] iocp.save_sol;
             )
         }
@@ -829,6 +875,7 @@ namespace NodeGLPK {
                  parm(),
                  ctx() {
                TermHookGuard hookguard{lp->info_};
+               MemStatsGuard mguard{lp->memstats_}; 
                glp_init_iocp(&parm);
                glp_init_mip_ctx(&ctx);
                ctx.parm = &parm;
@@ -840,7 +887,7 @@ namespace NodeGLPK {
             }
             
             ~IntoptWorker(){
-                if (parm.cb_info) delete (Nan::Callback*)parm.cb_info;
+                if (parm.cb_info) delete static_cast<IocpCallbackInfo*>(parm.cb_info);
                 if (parm.save_sol) delete[] parm.save_sol;
             }
 
@@ -932,12 +979,13 @@ namespace NodeGLPK {
             
             Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             IntoptWorker *worker = new IntoptWorker(callback, lp);
-            if (!IocpInit(&worker->parm, info[0])){
+            if (!IocpInit(lp, &worker->parm, info[0])){
                 worker->Destroy();
                 return;
             }
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -950,6 +998,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
             TermHookGuard hookguard{lp->info_};
+            MemStatsGuard mguard{lp->memstats_}; 
             info.GetReturnValue().Set(glp_read_lp(lp->handle, NULL, V8TOCSTRING(info[0])));
         }
         
@@ -992,7 +1041,8 @@ namespace NodeGLPK {
             Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             ReadLpWorker *worker = new ReadLpWorker(callback, lp, V8TOCSTRING(info[0]));
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -1005,6 +1055,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
             TermHookGuard hookguard{lp->info_};
+            MemStatsGuard mguard{lp->memstats_}; 
             GLP_CATCH_RET(info.GetReturnValue().Set(glp_write_lp(lp->handle, NULL, V8TOCSTRING(info[0])));)
         }
         
@@ -1046,7 +1097,8 @@ namespace NodeGLPK {
             Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             WriteLpWorker *worker = new WriteLpWorker(callback, lp, V8TOCSTRING(info[0]));
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -1062,6 +1114,7 @@ namespace NodeGLPK {
             int ae_ind, re_ind;
 
             TermHookGuard hookguard{lp->info_};
+            MemStatsGuard mguard{lp->memstats_}; 
             GLP_CATCH_RET(glp_check_kkt(lp->handle, info[0]->Int32Value(), info[1]->Int32Value(), &ae_max, &ae_ind, &re_max, &re_ind);)
             
             Nan::Callback* cb = new Nan::Callback(Local<Function>::Cast(info[2]));
@@ -1089,6 +1142,7 @@ namespace NodeGLPK {
             int* plist = NULL;
             int ret = 0;
             TermHookGuard hookguard{lp->info_};
+            MemStatsGuard mguard{lp->memstats_}; 
             GLP_CATCH(
                 if (info[0]->IsInt32Array()) {
                     Local<Int32Array> list = Local<Int32Array>::Cast(info[0]);
@@ -1167,7 +1221,8 @@ namespace NodeGLPK {
             }
             
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -1177,6 +1232,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
             TermHookGuard hookguard{lp->info_};
+            MemStatsGuard mguard{lp->memstats_}; 
             GLP_CATCH_RET(
                 glp_bfcp bfcp;
                 glp_get_bfcp(lp->handle, &bfcp);
@@ -1202,6 +1258,7 @@ namespace NodeGLPK {
             V8CHECK(lp->thread.load(), "an async operation is inprogress");
             
             TermHookGuard hookguard{lp->info_};
+            MemStatsGuard mguard{lp->memstats_}; 
             GLP_CATCH_RET(
                       glp_bfcp bfcp;
                       glp_get_bfcp(lp->handle, &bfcp);
@@ -1278,7 +1335,8 @@ namespace NodeGLPK {
             Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
             ScaleWorker *worker = new ScaleWorker(callback, lp, info[0]->Int32Value());
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -1319,7 +1377,8 @@ namespace NodeGLPK {
             Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
             FactorizeWorker *worker = new FactorizeWorker(callback, lp);
             lp->thread = true;
-            EventEmitterDecorator* decorated = new EventEmitterDecorator(worker, lp->emitter_);
+            EventEmitterDecorator* eventemitting = new EventEmitterDecorator(worker, lp->emitter_);
+            MemStatsDecorator* decorated = new MemStatsDecorator(eventemitting, lp->memstats_);
             Nan::AsyncQueueWorker(decorated);
         }
         
@@ -1553,6 +1612,7 @@ namespace NodeGLPK {
         static Nan::Persistent<FunctionTemplate> constructor;
 
         std::shared_ptr<NodeEvent::EventEmitter> emitter_;
+        std::shared_ptr<glp_memstats> memstats_;
         std::shared_ptr<HookInfo> info_;
     public:
         glp_prob *handle;

--- a/src/problem.hpp
+++ b/src/problem.hpp
@@ -273,7 +273,7 @@ namespace NodeGLPK {
             V8CHECK(info.Length() != 0, "Wrong number of arguments");
 
             Problem* lp = ObjectWrap::Unwrap<Problem>(info.Holder());
-            V8CHECK(!lp->handle, "object deleted");
+            V8CHECK(!lp->memstats_, "object deleted");
 
             Local<v8::Object> ret = Nan::New<v8::Object>();
             ret->Set(Nan::New<v8::String>("count").ToLocalChecked(), Nan::New<v8::Number>(lp->memstats_->problem_mem_count));

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -97,9 +97,8 @@ namespace NodeGLPK {
             Tree* host = ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread.load(), "an async operation is inprogress");
-         
-            MemStatsGuard mguard{host->memstats_}; 
-            TermHookGuard hookguard{host->info_};
+        
+            GLP_CREATE_HOOK_GUARDS(host);
             int a_cnt, n_cnt, t_cnt;
             GLP_CATCH_RET(glp_ios_tree_size(host->handle, &a_cnt, &n_cnt, &t_cnt);)
             Local<Object> ret = Nan::New<Object>();
@@ -133,9 +132,8 @@ namespace NodeGLPK {
             Tree* host = ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread.load(), "an async operation is inprogress");
-            
-            MemStatsGuard mguard{host->memstats_}; 
-            TermHookGuard hookguard{host->info_};
+           
+            GLP_CREATE_HOOK_GUARDS(host); 
             glp_attr attr;
             GLP_CATCH_RET(glp_ios_row_attr(host->handle, info[0]->Int32Value(), &attr);)
             
@@ -157,9 +155,8 @@ namespace NodeGLPK {
             Tree* tree = ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread.load(), "an async operation is inprogress");
-            
-            MemStatsGuard mguard{tree->memstats_}; 
-            TermHookGuard hookguard{tree->info_};
+           
+            GLP_CREATE_HOOK_GUARDS(tree);
 
             Local<Int32Array> ind = Local<Int32Array>::Cast(info[3]);
             Local<Float64Array> val = Local<Float64Array>::Cast(info[4]);
@@ -200,9 +197,8 @@ namespace NodeGLPK {
             Tree* tree = ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread.load(), "an async operation is inprogress");
-            
-            MemStatsGuard mguard{tree->memstats_}; 
-            TermHookGuard hookguard{tree->info_};
+           
+            GLP_CREATE_HOOK_GUARDS(tree); 
             Local<Float64Array> x = Local<Float64Array>::Cast(info[0]);
             
             int count = (int)x->Length();

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -50,10 +50,11 @@ namespace NodeGLPK {
             constructor.Reset(tpl);
         }
 
-        static Local<Value> Instantiate(glp_tree* tree){
+        static Local<Value> Instantiate(glp_tree* tree, std::shared_ptr<glp_memstats> memstats) {
             Local<Function> cons = Nan::New<FunctionTemplate>(constructor)->GetFunction();
             Local<Value> ret = cons->NewInstance();
             Tree* host = ObjectWrap::Unwrap<Tree>(ret->ToObject());
+            host->memstats_ = memstats;
             host->handle = tree;
             host->thread = false;
             return ret;
@@ -96,7 +97,8 @@ namespace NodeGLPK {
             Tree* host = ObjectWrap::Unwrap<Tree>(info.Holder());
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread.load(), "an async operation is inprogress");
-          
+         
+            MemStatsGuard mguard{host->memstats_}; 
             TermHookGuard hookguard{host->info_};
             int a_cnt, n_cnt, t_cnt;
             GLP_CATCH_RET(glp_ios_tree_size(host->handle, &a_cnt, &n_cnt, &t_cnt);)
@@ -132,6 +134,7 @@ namespace NodeGLPK {
             V8CHECK(!host->handle, "object deleted");
             V8CHECK(host->thread.load(), "an async operation is inprogress");
             
+            MemStatsGuard mguard{host->memstats_}; 
             TermHookGuard hookguard{host->info_};
             glp_attr attr;
             GLP_CATCH_RET(glp_ios_row_attr(host->handle, info[0]->Int32Value(), &attr);)
@@ -155,6 +158,7 @@ namespace NodeGLPK {
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread.load(), "an async operation is inprogress");
             
+            MemStatsGuard mguard{tree->memstats_}; 
             TermHookGuard hookguard{tree->info_};
 
             Local<Int32Array> ind = Local<Int32Array>::Cast(info[3]);
@@ -197,6 +201,7 @@ namespace NodeGLPK {
             V8CHECK(!tree->handle, "object deleted");
             V8CHECK(tree->thread.load(), "an async operation is inprogress");
             
+            MemStatsGuard mguard{tree->memstats_}; 
             TermHookGuard hookguard{tree->info_};
             Local<Float64Array> x = Local<Float64Array>::Cast(info[0]);
             
@@ -210,6 +215,7 @@ namespace NodeGLPK {
         }
     private:
         std::shared_ptr<NodeEvent::EventEmitter> emitter_;
+        std::shared_ptr<glp_memstats> memstats_;
         std::shared_ptr<HookInfo> info_;
         
     public:

--- a/test/glpk-test.js
+++ b/test/glpk-test.js
@@ -5,6 +5,7 @@ const testRoot = require('path').resolve(__dirname, '..')
 const glp = require('bindings')({ module_root: testRoot, bindings: 'glpk' })
 const temp = require('temp').track()
 const fs = require('fs')
+const setupSimplexLP = require('./setup_simplex.js').setupSimplexLP
 
 glp.termOutput(false)
 
@@ -13,50 +14,6 @@ function nearly(n, magnitude) {
         magnitude = 1000000000000
     }
     return [ n - 1/magnitude, n + 1/magnitude ]
-}
-
-function setupSimplexLP() {
-    // LP inspired by sample.c in the glpk distribution
-    let lp = new glp.Problem()
-    lp.setProbName("sample")
-    lp.setObjDir(glp.MAX)
-
-    lp.addRows(3)
-    lp.setRowName(1, "p")
-    lp.setRowBnds(1, glp.UP, 0.0, 100.0)
-    lp.setRowName(2, "q")
-    lp.setRowBnds(2, glp.UP, 0.0, 600.0)
-    lp.setRowName(3, "r")
-    lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
-
-    lp.addCols(3)
-    lp.setColName(1, "x1")
-    lp.setColBnds(1, glp.LO, 0.0, 0.0);
-    lp.setObjCoef(1, 10.0)
-    lp.setColName(2, "x2")
-    lp.setColBnds(2, glp.LO, 0.0, 0.0);
-    lp.setObjCoef(2, 6.0)
-    lp.setColName(3, "x2")
-    lp.setColBnds(3, glp.LO, 0.0, 0.0);
-    lp.setObjCoef(3, 4.0)
-
-    let ia = new Int32Array(10);
-    let ja = new Int32Array(10);
-    let ar = new Float64Array(10);
-
-    ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
-    ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
-    ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
-    ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
-    ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
-    ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
-    ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
-    ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
-    ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
-
-    lp.loadMatrix(9, ia, ja, ar)
-
-    return lp
 }
 
 describe("Simplex problem tests", function() {
@@ -279,3 +236,5 @@ describe("Test glp_intopt_start, glp_intopt_run, glp_intopt_stop flow", function
         });
     });
 })
+
+

--- a/test/problem-memusage-test.js
+++ b/test/problem-memusage-test.js
@@ -31,7 +31,6 @@ describe('Verify problem.memStats', function() {
         })
         lp.intopt({ msgLev: glp.MSG_ALL, presolve: glp.ON }, function() {
             let info = lp.memStats()
-            let globalInfo = glp.glpMemInfo()
 
             expect(info).to.be.an.object()
             expect(info).to.include(['count','cpeak','total','tpeak'])
@@ -44,6 +43,7 @@ describe('Verify problem.memStats', function() {
             expect(info.tpeak).to.be.at.least(maxObserved)
             expect(info.tpeak).to.be.at.least(20000)
             lp.delete()
+            info = lp.memStats()
 
             done();
         })

--- a/test/problem-memusage-test.js
+++ b/test/problem-memusage-test.js
@@ -1,0 +1,52 @@
+'use strict;'
+
+const expect = require('code').expect
+const testRoot = require('path').resolve(__dirname, '..')
+const glp = require('bindings')({ module_root: testRoot, bindings: 'glpk' })
+const temp = require('temp').track()
+const fs = require('fs')
+const setupSimplexLP = require('./setup_simplex.js').setupSimplexLP
+
+glp.termOutput(false)
+
+describe('Verify problem.memStats', function() {
+    it('should have meminfo as the problem is processed asynchronously, and when done', function(done) {
+        let lp = setupSimplexLP()
+        let idx = 0;
+        let maxObserved = 0
+        lp.on('log', function(msg) {
+            let info = lp.memStats()
+
+            expect(info).to.be.an.object()
+            expect(info).to.include(['count','cpeak','total','tpeak'])
+            expect(info.count).to.be.a.number()
+            expect(info.cpeak).to.be.a.number()
+            expect(info.total).to.be.a.number()
+            expect(info.tpeak).to.be.a.number()
+            expect(info.tpeak).to.be.at.least(info.total)
+            expect(info.cpeak).to.be.at.least(info.count)
+            if (maxObserved < info.total) {
+                maxObserved = info.total
+            }
+        })
+        lp.intopt({ msgLev: glp.MSG_ALL, presolve: glp.ON }, function() {
+            let info = lp.memStats()
+            let globalInfo = glp.glpMemInfo()
+
+            expect(info).to.be.an.object()
+            expect(info).to.include(['count','cpeak','total','tpeak'])
+            expect(info.count).to.be.a.number()
+            expect(info.cpeak).to.be.a.number()
+            expect(info.total).to.be.a.number()
+            expect(info.tpeak).to.be.a.number()
+            expect(info.tpeak).to.be.at.least(info.total)
+            expect(info.cpeak).to.be.at.least(info.count)
+            expect(info.tpeak).to.be.at.least(maxObserved)
+            expect(info.tpeak).to.be.at.least(20000)
+            lp.delete()
+
+            done();
+        })
+    })
+})
+

--- a/test/setup_simplex.js
+++ b/test/setup_simplex.js
@@ -1,0 +1,54 @@
+'use strict;'
+const testRoot = require('path').resolve(__dirname, '..')
+const glp = require('bindings')({ module_root: testRoot, bindings: 'glpk' })
+
+glp.termOutput(false)
+
+function setupSimplexLP() {
+    // LP inspired by sample.c in the glpk distribution
+    let lp = new glp.Problem()
+    lp.setProbName("sample")
+    lp.setObjDir(glp.MAX)
+
+    lp.addRows(3)
+    lp.setRowName(1, "p")
+    lp.setRowBnds(1, glp.UP, 0.0, 100.0)
+    lp.setRowName(2, "q")
+    lp.setRowBnds(2, glp.UP, 0.0, 600.0)
+    lp.setRowName(3, "r")
+    lp.setRowBnds(3, glp.UP, 0.0, 300.0) 
+
+    lp.addCols(3)
+    lp.setColName(1, "x1")
+    lp.setColBnds(1, glp.LO, 0.0, 0.0);
+    lp.setObjCoef(1, 10.0)
+    lp.setColName(2, "x2")
+    lp.setColBnds(2, glp.LO, 0.0, 0.0);
+    lp.setObjCoef(2, 6.0)
+    lp.setColName(3, "x2")
+    lp.setColBnds(3, glp.LO, 0.0, 0.0);
+    lp.setObjCoef(3, 4.0)
+
+    let ia = new Int32Array(10);
+    let ja = new Int32Array(10);
+    let ar = new Float64Array(10);
+
+    ia[1] = 1; ja[1] = 1; ar[1] = 1.0;
+    ia[2] = 1; ja[2] = 2; ar[2] = 1.0;
+    ia[3] = 1; ja[3] = 3; ar[3] = 1.0;
+    ia[4] = 2; ja[4] = 1; ar[4] = 10.0;
+    ia[5] = 3; ja[5] = 1; ar[5] = 2.0;
+    ia[6] = 2; ja[6] = 2; ar[6] = 4.0;
+    ia[7] = 3; ja[7] = 2; ar[7] = 2.0;
+    ia[8] = 2; ja[8] = 3; ar[8] = 5.0;
+    ia[9] = 3; ja[9] = 3; ar[9] = 6.0;
+
+    lp.loadMatrix(9, ia, ja, ar)
+
+    return lp
+}
+
+module.exports = {
+    setupSimplexLP
+}
+


### PR DESCRIPTION
This PR adds memStats() methods to both Mathprog and Problem. This lets you get memory statistics per problem object.  

Adds an RAII guard for main-thread contexts and another decorator which uses the same for worker-threads. 